### PR TITLE
Introduce provable logging with loglevels

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -6,5 +6,4 @@ export * from "./zkProgrammable/ProvableMethodExecutionContext";
 export * from "./zkProgrammable/provableMethod";
 export * from "./utils";
 export * from "./dependencyFactory/DependencyFactory";
-// eslint-disable-next-line import/no-unused-modules
-export { default as log } from "loglevel";
+export * from "./log";

--- a/packages/common/src/log.ts
+++ b/packages/common/src/log.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import loglevel from "loglevel";
+import { Provable } from "snarkyjs";
+
+function logProvable(
+  logFunction: (...args: unknown[]) => void,
+  ...args: any[]
+) {
+  Provable.asProver(() => {
+    const prettyArguments = [];
+    for (const argument of args) {
+      if (argument?.toPretty !== undefined) {
+        prettyArguments.push(argument.toPretty());
+      } else {
+        try {
+          prettyArguments.push(JSON.parse(JSON.stringify(argument)));
+        } catch {
+          prettyArguments.push(argument);
+        }
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    logFunction(...prettyArguments);
+  });
+}
+
+export const log = {
+  provable: {
+    info: (...args: unknown[]) => {
+      logProvable(loglevel.info, ...args);
+    },
+
+    debug: (...args: unknown[]) => {
+      logProvable(loglevel.debug, ...args);
+    },
+
+    error: (...args: unknown[]) => {
+      logProvable(loglevel.error, ...args);
+    },
+
+    trace: (...args: unknown[]) => {
+      logProvable(loglevel.trace, ...args);
+    },
+
+    warn: (...args: unknown[]) => {
+      logProvable(loglevel.warn, ...args);
+    },
+  },
+
+  ...loglevel,
+};

--- a/packages/common/src/log.ts
+++ b/packages/common/src/log.ts
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/unbound-method */
-import loglevel from "loglevel";
+/* eslint-disable @typescript-eslint/unbound-method, putout/putout */
+import loglevel, { LogLevelDesc } from "loglevel";
 import { Provable } from "snarkyjs";
 
 function logProvable(
@@ -47,5 +47,33 @@ export const log = {
     },
   },
 
-  ...loglevel,
+  info: (...args: unknown[]) => {
+    loglevel.info(...args);
+  },
+
+  debug: (...args: unknown[]) => {
+    loglevel.debug(...args);
+  },
+
+  error: (...args: unknown[]) => {
+    loglevel.error(...args);
+  },
+
+  trace: (...args: unknown[]) => {
+    loglevel.trace(...args);
+  },
+
+  warn: (...args: unknown[]) => {
+    loglevel.warn(...args);
+  },
+
+  setLevel: (level: LogLevelDesc) => {
+    loglevel.setLevel(level);
+  },
+
+  get levels() {
+    return loglevel.levels;
+  },
+
+  getLevel: () => loglevel.getLevel(),
 };

--- a/packages/protocol/src/state/assert/assert.test.ts
+++ b/packages/protocol/src/state/assert/assert.test.ts
@@ -18,7 +18,7 @@ describe("assert", () => {
     executionContext.setup({
       transaction: undefined as unknown as RuntimeTransaction,
       networkState: undefined as unknown as NetworkState,
-    })
+    });
   });
 
   afterEach(() => {

--- a/packages/protocol/src/state/assert/assert.test.ts
+++ b/packages/protocol/src/state/assert/assert.test.ts
@@ -5,6 +5,8 @@ import { container } from "tsyringe";
 
 import { assert } from "./assert";
 import { RuntimeMethodExecutionContext } from "../context/RuntimeMethodExecutionContext";
+import { RuntimeTransaction } from "../../model/transaction/RuntimeTransaction";
+import { NetworkState } from "../../model/network/NetworkState";
 
 describe("assert", () => {
   const defaultStatusMessage = "something went wrong";
@@ -12,6 +14,11 @@ describe("assert", () => {
 
   beforeEach(() => {
     executionContext.beforeMethod("testConstructor", "test", []);
+
+    executionContext.setup({
+      transaction: undefined as unknown as RuntimeTransaction,
+      networkState: undefined as unknown as NetworkState,
+    })
   });
 
   afterEach(() => {

--- a/packages/protocol/src/state/assert/assert.ts
+++ b/packages/protocol/src/state/assert/assert.ts
@@ -3,7 +3,6 @@ import { container } from "tsyringe";
 import { log } from "@proto-kit/common";
 
 import { RuntimeMethodExecutionContext } from "../context/RuntimeMethodExecutionContext";
-import { exec } from "child_process";
 
 /**
  * Maintains an execution status of the current runtime module method,
@@ -17,6 +16,8 @@ import { exec } from "child_process";
 export function assert(condition: Bool, message?: string) {
   const executionContext = container.resolve(RuntimeMethodExecutionContext);
   const previousStatus = executionContext.current().result.status;
+  console.log(Bool.toFields(condition)[0].toString());
+  console.log(Bool.toFields(previousStatus)[0].toString());
   const status = Provable.if(previousStatus, Bool, condition, previousStatus);
 
   if (!condition.toBoolean()) {

--- a/packages/protocol/src/state/assert/assert.ts
+++ b/packages/protocol/src/state/assert/assert.ts
@@ -16,8 +16,6 @@ import { RuntimeMethodExecutionContext } from "../context/RuntimeMethodExecution
 export function assert(condition: Bool, message?: string) {
   const executionContext = container.resolve(RuntimeMethodExecutionContext);
   const previousStatus = executionContext.current().result.status;
-  console.log(Bool.toFields(condition)[0].toString());
-  console.log(Bool.toFields(previousStatus)[0].toString());
   const status = Provable.if(previousStatus, Bool, condition, previousStatus);
 
   if (!condition.toBoolean()) {

--- a/packages/protocol/test/State.test.ts
+++ b/packages/protocol/test/State.test.ts
@@ -1,0 +1,45 @@
+import "reflect-metadata";
+import { Bool, Field, Provable, UInt64 } from "snarkyjs";
+import { container } from "tsyringe";
+
+import {
+  NetworkState,
+  noop,
+  RuntimeMethodExecutionContext,
+  RuntimeTransaction,
+  State,
+  StateService,
+  StateServiceProvider,
+} from "../src";
+
+describe("state", () => {
+  beforeEach(() => {
+    const executionContext = container.resolve(RuntimeMethodExecutionContext);
+
+    executionContext.setup({
+      transaction: undefined as unknown as RuntimeTransaction,
+      networkState: undefined as unknown as NetworkState,
+    });
+  });
+
+  it("should decode state correctly", () => {
+    expect.assertions(2);
+
+    const state = State.from<UInt64>(UInt64);
+    const stateService: StateService = {
+      get: () => [Field(123)],
+
+      set: () => {
+        noop();
+      },
+    };
+    state.stateServiceProvider = new StateServiceProvider();
+    state.stateServiceProvider.setCurrentStateService(stateService);
+    state.path = Field(1);
+
+    const retrieved = state.get();
+
+    expect(retrieved.isSome).toStrictEqual(Bool(true));
+    expect(retrieved.value).toStrictEqual(UInt64.from(123));
+  });
+});

--- a/packages/sequencer/test/integration/BlockProduction.test.ts
+++ b/packages/sequencer/test/integration/BlockProduction.test.ts
@@ -61,7 +61,7 @@ describe("block production", () => {
   beforeEach(async () => {
     // container.reset();
 
-    log.setLevel("TRACE");
+    log.setLevel("DEBUG");
 
     const stateService = new InMemoryStateService()
 

--- a/packages/sequencer/test/integration/BlockProduction.test.ts
+++ b/packages/sequencer/test/integration/BlockProduction.test.ts
@@ -61,7 +61,7 @@ describe("block production", () => {
   beforeEach(async () => {
     // container.reset();
 
-    log.setLevel("DEBUG");
+    log.setLevel(log.levels.DEBUG);
 
     const stateService = new InMemoryStateService()
 
@@ -200,7 +200,7 @@ describe("block production", () => {
       })
     );
 
-    console.log("Starting second block");
+    log.info("Starting second block");
 
     block = await blockTrigger.produceBlock();
 

--- a/packages/sequencer/test/integration/mocks/Balance.ts
+++ b/packages/sequencer/test/integration/mocks/Balance.ts
@@ -4,8 +4,8 @@ import {
   RuntimeModule,
   state,
 } from "@proto-kit/module";
-import { Presets, range } from "@proto-kit/common";
-import { Bool, Field, Provable, PublicKey, UInt64 } from "snarkyjs";
+import { log, Presets, range } from "@proto-kit/common";
+import { Bool, Field, PublicKey, UInt64 } from "snarkyjs";
 import { Admin } from "@proto-kit/module/test/modules/Admin";
 import { Option, State, StateMap, assert } from "@proto-kit/protocol";
 
@@ -50,7 +50,9 @@ export class Balance extends RuntimeModule<object> {
   @runtimeMethod()
   public addBalance(address: PublicKey, value: UInt64) {
     const balance = this.balances.get(address);
-    Provable.log("Balance:", balance.isSome, balance.value);
+
+    log.provable.debug("Balance:", balance.isSome, balance.value);
+
     const newBalance = balance.value.add(value);
     this.balances.set(address, newBalance);
   }
@@ -60,9 +62,9 @@ export class Balance extends RuntimeModule<object> {
     const address = this.transaction.sender;
     const balance = this.balances.get(address);
 
-    Provable.log("Sender:", address);
-    Provable.log("Balance:", balance.isSome, balance.value);
-    Provable.log("BlockHeight:", this.network.block.height);
+    log.provable.debug("Sender:", address);
+    log.provable.debug("Balance:", balance.isSome, balance.value);
+    log.provable.debug("BlockHeight:", this.network.block.height);
 
     assert(blockHeight.equals(this.network.block.height));
 


### PR DESCRIPTION
In addition to the current logging api
```typescript
log.setLevel(log.levels.Info);
log.info("log");
```
this PR adds the following methods
```
log.provable.info(provableObject);
```
which internally uses the snarkyjs implementation to log provable objects inside prover code and respects the globally set loglevel