### PR TITLE
fix: temporarily remove account state due to known bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27270,7 +27270,7 @@
     },
     "packages/common": {
       "name": "@proto-kit/common",
-      "version": "0.1.1-develop.160+5120680",
+      "version": "0.1.1-develop.241+b5c9a48",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -27289,7 +27289,7 @@
     },
     "packages/module": {
       "name": "@proto-kit/module",
-      "version": "0.1.1-develop.160+5120680",
+      "version": "0.1.1-develop.241+b5c9a48",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -27309,7 +27309,7 @@
     },
     "packages/protocol": {
       "name": "@proto-kit/protocol",
-      "version": "0.1.1-develop.160+5120680",
+      "version": "0.1.1-develop.241+b5c9a48",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -27329,7 +27329,7 @@
     },
     "packages/sdk": {
       "name": "@proto-kit/sdk",
-      "version": "0.1.1-develop.160+5120680",
+      "version": "0.1.1-develop.241+b5c9a48",
       "license": "MIT",
       "dependencies": {
         "comlink": "^4.4.1",
@@ -27352,7 +27352,7 @@
     },
     "packages/sequencer": {
       "name": "@proto-kit/sequencer",
-      "version": "0.1.1-develop.160+5120680",
+      "version": "0.1.1-develop.241+b5c9a48",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.5.4",

--- a/packages/protocol/src/prover/statetransition/StateTransitionProver.ts
+++ b/packages/protocol/src/prover/statetransition/StateTransitionProver.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Experimental, Field, Provable, SelfProof } from "snarkyjs";
+import { Bool, Experimental, Field, Provable, SelfProof } from "snarkyjs";
 import { injectable } from "tsyringe";
 import {
   AreProofsEnabled,
@@ -38,8 +38,8 @@ const errors = {
   propertyNotMatching: (property: string, step: string) =>
     `${property} not matching ${step}`,
 
-  merkleWitnessNotCorrect: (index: number) =>
-    `MerkleWitness not valid for StateTransition (${index})`,
+  merkleWitnessNotCorrect: (index: number, type: string) =>
+    `MerkleWitness not valid for StateTransition (${index}, type ${type})`,
 
   noWitnessProviderSet: () =>
     new Error(
@@ -202,9 +202,15 @@ export class StateTransitionProverProgrammable extends ZkProgrammable<
       transition.path,
       transition.from.value
     );
+
     membershipValid
       .or(transition.from.isSome.not())
-      .assertTrue(errors.merkleWitnessNotCorrect(index));
+      .assertTrue(
+        errors.merkleWitnessNotCorrect(
+          index,
+          type.isNormal().toBoolean() ? "normal" : "protocol"
+        )
+      );
 
     const newRoot = MerkleTreeUtils.computeRoot(
       treeWitness,

--- a/packages/sdk/src/appChain/TestingAppChain.ts
+++ b/packages/sdk/src/appChain/TestingAppChain.ts
@@ -80,7 +80,9 @@ export class TestingAppChain<
       sequencer: sequencer as any,
 
       protocol: VanillaProtocol.from(
-        { AccountStateModule },
+        {
+          // AccountStateModule
+        } as any,
         new InMemoryStateService()
       ),
 

--- a/packages/sequencer/src/protocol/production/TransactionTraceService.ts
+++ b/packages/sequencer/src/protocol/production/TransactionTraceService.ts
@@ -126,12 +126,6 @@ export class TransactionTraceService {
       stateTransitions
         .filter((st) => st.to.isSome.toBoolean())
         .map(async (st) => {
-          console.log(
-            `Applying ${st.path.toString()} -> ${st.to
-              .toFields()
-              .map((x) => x.toString())
-              .reduce((a, b) => a + "," + b)}`
-          );
           await stateService.setAsync(st.path, st.to.toFields());
         })
     );


### PR DESCRIPTION
Removes the `AccountStateModule` from `VanillaProtocol` until nonce tracking is fixed in the sequencer.