### PR TITLE
Implement upstream event emitters in ModuleContainer

### DIFF
--- a/packages/common/src/config/ModuleContainer.ts
+++ b/packages/common/src/config/ModuleContainer.ts
@@ -3,9 +3,9 @@ import "reflect-metadata";
 
 import {
   DependencyContainer,
-  Frequency,
+  Frequency, injectable,
   InjectionToken,
-  Lifecycle,
+  Lifecycle
 } from "tsyringe";
 import log from "loglevel";
 
@@ -225,7 +225,7 @@ export class ModuleContainer<
 
   public get events(): ContainerEvents<Modules> {
     const moduleNames = this.moduleNames as StringKeyOf<Modules>[];
-    moduleNames.reduce<ContainerEvents<Modules>>((acc, key) => {
+    const events = moduleNames.reduce<any>((acc, key) => {
       const module = this.resolve(key);
       if ((module as any)["events"] !== undefined) {
         const eventemitting = module as EventEmittingComponent<
@@ -237,6 +237,7 @@ export class ModuleContainer<
       }
       return acc;
     }, {});
+    return events as ContainerEvents<Modules>
   }
 
   /**

--- a/packages/common/src/config/ModuleContainer.ts
+++ b/packages/common/src/config/ModuleContainer.ts
@@ -126,7 +126,6 @@ export class ModuleContainer<
    * @returns list of module names
    */
   public get moduleNames() {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return Object.keys(this.definition.modules);
   }
 
@@ -173,7 +172,7 @@ export class ModuleContainer<
     modules: Modules,
     moduleName: string
   ): asserts moduleName is StringKeyOf<Modules> {
-    if(!this.isValidModuleName(modules, moduleName)){
+    if (!this.isValidModuleName(modules, moduleName)) {
       throw errors.onlyValidModuleNames(moduleName);
     }
   }
@@ -182,7 +181,7 @@ export class ModuleContainer<
     modules: Modules,
     moduleName: number | string | symbol
   ): moduleName is StringKeyOf<Modules> {
-    return Object.prototype.hasOwnProperty.call(modules, moduleName)
+    return Object.prototype.hasOwnProperty.call(modules, moduleName);
   }
 
   public assertContainerInitialized(

--- a/packages/common/src/config/ModuleContainer.ts
+++ b/packages/common/src/config/ModuleContainer.ts
@@ -116,6 +116,8 @@ export class ModuleContainer<
   // DI container holding all the registered modules
   private providedContainer?: DependencyContainer = undefined;
 
+  private eventEmitterProxy: EventEmitterProxy<Modules> | undefined = undefined;
+
   public constructor(public definition: ModuleContainerDefinition<Modules>) {
     super();
   }
@@ -171,16 +173,16 @@ export class ModuleContainer<
     modules: Modules,
     moduleName: string
   ): asserts moduleName is StringKeyOf<Modules> {
-    this.isValidModuleName(modules, moduleName);
+    if(!this.isValidModuleName(modules, moduleName)){
+      throw errors.onlyValidModuleNames(moduleName);
+    }
   }
 
   public isValidModuleName(
     modules: Modules,
     moduleName: number | string | symbol
-  ): asserts moduleName is StringKeyOf<Modules> {
-    if (!Object.prototype.hasOwnProperty.call(modules, moduleName)) {
-      throw errors.onlyValidModuleNames(moduleName);
-    }
+  ): moduleName is StringKeyOf<Modules> {
+    return Object.prototype.hasOwnProperty.call(modules, moduleName)
   }
 
   public assertContainerInitialized(
@@ -217,10 +219,9 @@ export class ModuleContainer<
     }
   }
 
-  private eventEmitterProxy = new EventEmitterProxy<Modules>(this);
-
   public get events(): EventEmitterProxy<Modules> {
-    return this.eventEmitterProxy;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.eventEmitterProxy!;
   }
 
   /**
@@ -363,5 +364,7 @@ export class ModuleContainer<
 
     // register all provided modules when the container is created
     this.registerModules(this.definition.modules);
+
+    this.eventEmitterProxy = new EventEmitterProxy<Modules>(this);
   }
 }

--- a/packages/common/src/events/EventEmitterProxy.ts
+++ b/packages/common/src/events/EventEmitterProxy.ts
@@ -1,17 +1,12 @@
-import { EventEmitter } from "./EventEmitter";
-import {
+import type {
   BaseModuleType,
   ModuleContainer,
   ModulesRecord,
 } from "../config/ModuleContainer";
-import { StringKeyOf } from "../types";
-import { EventEmittingComponent, EventsRecord } from "./EventEmittingComponent";
+import { StringKeyOf, UnionToIntersection } from "../types";
 
-type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (
-  x: infer I
-) => void
-  ? I
-  : never;
+import { EventEmitter } from "./EventEmitter";
+import { EventEmittingComponent, EventsRecord } from "./EventEmittingComponent";
 
 export type CastToEventsRecord<Record> = Record extends EventsRecord
   ? Record
@@ -35,11 +30,8 @@ export type FlattenedContainerEvents<Modules extends ModulesRecord> =
   FlattenObject<ContainerEvents<Modules>>;
 
 export class EventEmitterProxy<
-  Modules extends ModulesRecord,
-  // TODO Remove as input
-> extends EventEmitter<CastToEventsRecord<
-  FlattenedContainerEvents<Modules>
->> {
+  Modules extends ModulesRecord
+> extends EventEmitter<CastToEventsRecord<FlattenedContainerEvents<Modules>>> {
   public constructor(private readonly container: ModuleContainer<Modules>) {
     super();
     container.moduleNames.forEach((moduleName) => {
@@ -49,7 +41,7 @@ export class EventEmitterProxy<
         const module = container.resolve(moduleName);
         if (this.isEventEmitter(module)) {
           module.events.onAll((events: any, args: unknown[]) => {
-            this.emit(events, ...(args as any ));
+            this.emit(events, ...(args as any));
           });
         }
       }

--- a/packages/common/src/events/EventEmitterProxy.ts
+++ b/packages/common/src/events/EventEmitterProxy.ts
@@ -1,5 +1,9 @@
 import { EventEmitter } from "./EventEmitter";
-import { ModuleContainer, ModulesRecord } from "../config/ModuleContainer";
+import {
+  BaseModuleType,
+  ModuleContainer,
+  ModulesRecord,
+} from "../config/ModuleContainer";
 import { StringKeyOf } from "../types";
 import { EventEmittingComponent, EventsRecord } from "./EventEmittingComponent";
 
@@ -13,14 +17,15 @@ export type CastToEventsRecord<Record> = Record extends EventsRecord
   ? Record
   : {};
 
-export type ContainerEvents<Modules extends ModulesRecord> = {
-  [Key in StringKeyOf<Modules>]: InstanceType<
-    Modules[Key]
-  > extends EventEmittingComponent<infer Events>
+export type ModuleEvents<ModuleType extends BaseModuleType> =
+  InstanceType<ModuleType> extends EventEmittingComponent<infer Events>
     ? Events
-    : InstanceType<Modules[Key]> extends ModuleContainer<infer NestedModules>
+    : InstanceType<ModuleType> extends ModuleContainer<infer NestedModules>
     ? CastToEventsRecord<ContainerEvents<NestedModules>>
     : EventsRecord;
+
+export type ContainerEvents<Modules extends ModulesRecord> = {
+  [Key in StringKeyOf<Modules>]: ModuleEvents<Modules[Key]>;
 };
 
 export type FlattenObject<Target extends Record<string, EventsRecord>> =
@@ -29,56 +34,32 @@ export type FlattenObject<Target extends Record<string, EventsRecord>> =
 export type FlattenedContainerEvents<Modules extends ModulesRecord> =
   FlattenObject<ContainerEvents<Modules>>;
 
-type ReferenceRecord<EventRecord extends EventsRecord> = {
-  [Key in keyof EventRecord]: EventEmitter<Record<Key, EventRecord[Key]>>;
-};
-
 export class EventEmitterProxy<
   Modules extends ModulesRecord,
   // TODO Remove as input
-  EventRecord extends EventsRecord = CastToEventsRecord<
-    FlattenedContainerEvents<Modules>
-  >
-> implements Omit<EventEmitter<EventRecord>, "listeners">
-{
-  public constructor(private readonly container: ModuleContainer<Modules>) {}
-
-  public emit(
-    event: keyof EventRecord,
-    ...parameters: EventRecord[typeof event]
-  ): void {
-    throw new Error("Not to be used in this fashion");
-  }
-
-  private forEachEventEmitter(f: (emitter: EventEmitter<EventRecord>) => void) {
-    const moduleNames = this.container.moduleNames as StringKeyOf<Modules>[];
-
-    // Current strategy: Register event on all modules since
-    // we have no way narrowing that down
-    moduleNames.forEach((moduleName) => {
-      const module = this.container.resolve(moduleName);
-      const emitter = (module as any)["events"];
-      if (emitter !== undefined && emitter instanceof EventEmitter) {
-        f(emitter);
+> extends EventEmitter<CastToEventsRecord<
+  FlattenedContainerEvents<Modules>
+>> {
+  public constructor(private readonly container: ModuleContainer<Modules>) {
+    super();
+    container.moduleNames.forEach((moduleName) => {
+      if (
+        container.isValidModuleName(container.definition.modules, moduleName)
+      ) {
+        const module = container.resolve(moduleName);
+        if (this.isEventEmitter(module)) {
+          module.events.onAll((events: any, args: unknown[]) => {
+            this.emit(events, ...(args as any ));
+          });
+        }
       }
     });
   }
 
-  public on(
-    event: keyof EventRecord,
-    listener: (...args: EventRecord[typeof event]) => void
-  ): void {
-    this.forEachEventEmitter((emitter) => {
-      emitter.on(event, listener);
-    });
-  }
-
-  public off(
-    event: keyof EventRecord,
-    listener: (...args: EventRecord[typeof event]) => void
-  ): void {
-    this.forEachEventEmitter((emitter) => {
-      emitter.off(event, listener);
-    });
+  private isEventEmitter(
+    module: any
+  ): module is EventEmittingComponent<EventsRecord> {
+    const emitter = module.events;
+    return emitter !== undefined && emitter instanceof EventEmitter;
   }
 }

--- a/packages/common/src/events/EventEmitterProxy.ts
+++ b/packages/common/src/events/EventEmitterProxy.ts
@@ -1,0 +1,84 @@
+import { EventEmitter } from "./EventEmitter";
+import { ModuleContainer, ModulesRecord } from "../config/ModuleContainer";
+import { StringKeyOf } from "../types";
+import { EventEmittingComponent, EventsRecord } from "./EventEmittingComponent";
+
+type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (
+  x: infer I
+) => void
+  ? I
+  : never;
+
+export type CastToEventsRecord<Record> = Record extends EventsRecord
+  ? Record
+  : {};
+
+export type ContainerEvents<Modules extends ModulesRecord> = {
+  [Key in StringKeyOf<Modules>]: InstanceType<
+    Modules[Key]
+  > extends EventEmittingComponent<infer Events>
+    ? Events
+    : InstanceType<Modules[Key]> extends ModuleContainer<infer NestedModules>
+    ? CastToEventsRecord<ContainerEvents<NestedModules>>
+    : EventsRecord;
+};
+
+export type FlattenObject<Target extends Record<string, EventsRecord>> =
+  UnionToIntersection<Target[keyof Target]>;
+
+export type FlattenedContainerEvents<Modules extends ModulesRecord> =
+  FlattenObject<ContainerEvents<Modules>>;
+
+type ReferenceRecord<EventRecord extends EventsRecord> = {
+  [Key in keyof EventRecord]: EventEmitter<Record<Key, EventRecord[Key]>>;
+};
+
+export class EventEmitterProxy<
+  Modules extends ModulesRecord,
+  // TODO Remove as input
+  EventRecord extends EventsRecord = CastToEventsRecord<
+    FlattenedContainerEvents<Modules>
+  >
+> implements Omit<EventEmitter<EventRecord>, "listeners">
+{
+  public constructor(private readonly container: ModuleContainer<Modules>) {}
+
+  public emit(
+    event: keyof EventRecord,
+    ...parameters: EventRecord[typeof event]
+  ): void {
+    throw new Error("Not to be used in this fashion");
+  }
+
+  private forEachEventEmitter(f: (emitter: EventEmitter<EventRecord>) => void) {
+    const moduleNames = this.container.moduleNames as StringKeyOf<Modules>[];
+
+    // Current strategy: Register event on all modules since
+    // we have no way narrowing that down
+    moduleNames.forEach((moduleName) => {
+      const module = this.container.resolve(moduleName);
+      const emitter = (module as any)["events"];
+      if (emitter !== undefined && emitter instanceof EventEmitter) {
+        f(emitter);
+      }
+    });
+  }
+
+  public on(
+    event: keyof EventRecord,
+    listener: (...args: EventRecord[typeof event]) => void
+  ): void {
+    this.forEachEventEmitter((emitter) => {
+      emitter.on(event, listener);
+    });
+  }
+
+  public off(
+    event: keyof EventRecord,
+    listener: (...args: EventRecord[typeof event]) => void
+  ): void {
+    this.forEachEventEmitter((emitter) => {
+      emitter.off(event, listener);
+    });
+  }
+}

--- a/packages/common/src/events/EventEmittingComponent.ts
+++ b/packages/common/src/events/EventEmittingComponent.ts
@@ -1,10 +1,6 @@
 import type { EventEmitter } from "./EventEmitter";
 
-export type EventPayload = unknown[];
-
-export interface EventsRecord {
-  [key: string]: EventPayload;
-}
+export type EventsRecord = Record<string, unknown[]>;
 
 export interface EventEmittingComponent<Events extends EventsRecord> {
   events: EventEmitter<Events>;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -11,3 +11,4 @@ export * from "./dependencyFactory/DependencyFactory";
 export * from "./log";
 export * from "./events/EventEmittingComponent";
 export * from "./events/EventEmitter";
+export * from "./events/EventEmitterProxy";

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -17,3 +17,9 @@ export type StringKeyOf<Target extends object> = Extract<keyof Target, string> &
 export type ArrayElement<ArrayType extends readonly unknown[]> =
   // eslint-disable-next-line putout/putout
   ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+
+export type UnionToIntersection<Union> = (
+  Union extends any ? (x: Union) => void : never
+) extends (x: infer Intersection) => void
+  ? Intersection
+  : never;

--- a/packages/common/test/config/ContainerEvents.test.ts
+++ b/packages/common/test/config/ContainerEvents.test.ts
@@ -10,6 +10,11 @@ import {
   ModulesRecord, TypedClass
 } from "../../src";
 import { injectable, container as tsyringeContainer } from "tsyringe";
+import {
+  ContainerEvents,
+  FlattenedContainerEvents,
+  FlattenObject
+} from "../../src/events/EventEmitterProxy";
 
 class TestContainer<
   Modules extends ModulesRecord
@@ -27,26 +32,40 @@ class TestModule
   events = new EventEmitter<TestEvents>();
 }
 
+interface TestEvents2 extends EventsRecord {
+  test2: [number];
+}
+
+class TestModule2
+  extends ConfigurableModule<{}>
+  implements BaseModuleInstanceType, EventEmittingComponent<TestEvents2> {
+  events = new EventEmitter()
+}
+
+type X = {
+  test: TypedClass<TestModule>,
+  test2: TypedClass<TestModule2>
+}
+type Y = FlattenObject<ContainerEvents<X>>
+type Z = FlattenedContainerEvents<X>
+const y: Y = {
+  test: ["asd"],
+  // test2: [2]
+}
+
 describe("test event propagation", () => {
   it("should work corretly", () => {
     const container = new TestContainer({
       modules: {
-        test: TestModule
+        test: TestModule,
+        test2: TestModule2
       }
     })
 
     container.create(() => tsyringeContainer.createChildContainer())
 
-    type X = {
-      test: TypedClass<TestModule>
-    }
-    type Y = Flatten<X>
+    container.events.on("test", (s: unknown) => {
 
-
-    const t: Y = {
-
-    }
-
-    // container.events.
+    })
   });
 });

--- a/packages/common/test/config/ContainerEvents.test.ts
+++ b/packages/common/test/config/ContainerEvents.test.ts
@@ -1,0 +1,52 @@
+import "reflect-metadata";
+import {
+  BaseModuleInstanceType,
+  BaseModuleType,
+  ConfigurableModule,
+  EventEmitter,
+  EventEmittingComponent,
+  EventsRecord,
+  ModuleContainer,
+  ModulesRecord, TypedClass
+} from "../../src";
+import { injectable, container as tsyringeContainer } from "tsyringe";
+
+class TestContainer<
+  Modules extends ModulesRecord
+> extends ModuleContainer<Modules> {}
+
+interface TestEvents extends EventsRecord {
+  test: [string];
+}
+
+@injectable()
+class TestModule
+  extends ConfigurableModule<{}>
+  implements BaseModuleInstanceType, EventEmittingComponent<TestEvents>
+{
+  events = new EventEmitter<TestEvents>();
+}
+
+describe("test event propagation", () => {
+  it("should work corretly", () => {
+    const container = new TestContainer({
+      modules: {
+        test: TestModule
+      }
+    })
+
+    container.create(() => tsyringeContainer.createChildContainer())
+
+    type X = {
+      test: TypedClass<TestModule>
+    }
+    type Y = Flatten<X>
+
+
+    const t: Y = {
+
+    }
+
+    // container.events.
+  });
+});

--- a/packages/module/src/runtime/Runtime.ts
+++ b/packages/module/src/runtime/Runtime.ts
@@ -267,7 +267,7 @@ export class Runtime<Modules extends RuntimeModulesRecord>
     }
     const [moduleName, methodName] = methodDescriptor;
 
-    this.isValidModuleName(this.definition.modules, moduleName);
+    this.assertIsValidModuleName(this.definition.modules, moduleName);
     const module = this.resolve(moduleName);
 
     // eslint-disable-next-line max-len

--- a/packages/sequencer/src/helpers/query/QueryBuilderFactory.ts
+++ b/packages/sequencer/src/helpers/query/QueryBuilderFactory.ts
@@ -2,7 +2,7 @@
 /* eslint-disable guard-for-in */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable putout/putout */
-import { TypedClass } from "@proto-kit/common";
+import { StringKeyOf, TypedClass } from "@proto-kit/common";
 import {
   Runtime,
   RuntimeModule,
@@ -65,6 +65,10 @@ export type Query<
   [Key in keyof RuntimeModules]: ModuleQuery<InstanceType<RuntimeModules[Key]>>;
 };
 
+function isStringKeyOf(key: string | number | symbol): key is string {
+  return typeof key === "string";
+}
+
 export const QueryBuilderFactory = {
   // eslint-disable-next-line sonarjs/cognitive-complexity
   fillQuery<Module>(
@@ -117,8 +121,8 @@ export const QueryBuilderFactory = {
 
     return Object.keys(modules).reduce<
       Query<RuntimeModule<unknown>, RuntimeModules>
-    >((query, runtimeModuleName: keyof RuntimeModules) => {
-      runtime.isValidModuleName(modules, runtimeModuleName);
+    >((query, runtimeModuleName: string) => {
+      runtime.assertIsValidModuleName(modules, runtimeModuleName);
 
       const runtimeModule = runtime.resolve(runtimeModuleName);
 
@@ -139,9 +143,11 @@ export const QueryBuilderFactory = {
   ): Query<ProtocolModule<unknown>, ProtocolModules> {
     const { modules } = protocol.definition;
 
-    return Object.keys(modules).reduce<Query<ProtocolModule<unknown>, ProtocolModules>>(
-      (query, protocolModuleName: keyof ProtocolModules) => {
-        protocol.isValidModuleName(modules, protocolModuleName);
+    return Object.keys(modules).reduce<
+      Query<ProtocolModule<unknown>, ProtocolModules>
+    >(
+      (query, protocolModuleName: string) => {
+        protocol.assertIsValidModuleName(modules, protocolModuleName);
 
         const protocolModule = protocol.resolve(protocolModuleName);
 

--- a/packages/sequencer/src/protocol/production/unproven/UnprovenProducerModule.ts
+++ b/packages/sequencer/src/protocol/production/unproven/UnprovenProducerModule.ts
@@ -73,12 +73,17 @@ export class UnprovenProducerModule
         }
 
         log.info(`Produced unproven block (${block.transactions.length} txs)`);
-        this.events.emit("unprovenBlockProduced", [block]);
+        this.events.emit("unprovenBlockProduced", block);
 
         // Generate metadata for next block
         // eslint-disable-next-line no-warning-comments
         // TODO: make async of production in the future
-        const metadata = await this.executionService.generateMetadataForNextBlock(block, this.unprovenMerkleStore, true)
+        const metadata =
+          await this.executionService.generateMetadataForNextBlock(
+            block,
+            this.unprovenMerkleStore,
+            true
+          );
         await this.unprovenBlockQueue.pushMetadata(metadata);
 
         return block;


### PR DESCRIPTION
This PR enables ModuleContainers to collect and aggregate all events emitted by its children modules in a type-safe way. 
This allows for users to listen to events on a container while the event is actually dispatched from one of the modules inside the container (or further down the container tree). 