### PR TITLE
fix: Missed hash function invocation

### DIFF
--- a/packages/sequencer/src/mempool/PendingTransaction.ts
+++ b/packages/sequencer/src/mempool/PendingTransaction.ts
@@ -139,7 +139,7 @@ export class PendingTransaction extends UnsignedTransaction {
 
   public toJSON(): PendingTransactionJSONType {
     return {
-      hash: this.hash.toString(),
+      hash: this.hash().toString(),
       methodId: this.methodId.toJSON(),
       nonce: this.nonce.toString(),
       sender: this.sender.toBase58(),


### PR DESCRIPTION
Because of missed invocation, toJson returns now
{"hash":"hash() {\n        return o1js__WEBPACK_IMPORTED_MODULE_0__.Poseidon.hash([\n            this.methodId,\n            ...this.sender.toFields(),\n            ...this.nonce.toFields(),\n            this.argsHash(),\n        ]);\n    }","methodId":"28638683142335382319276261241850521219056839707793153809050830342089105615115","nonce":"1","sender":"B62qkh5QbigkTTXF464h5k6GW76SHL7wejUbKxKy5vZ9qr9dEcowe6G","argsFields":["115","100","102","115","100","102","115","100","102","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","0","1","1714780800000","1714780800000","1714867200000","1714867200000","30000000000","0"],"isMessage":false,"signature":{"r":"3265.