### PR TITLE
Shim connection support

### DIFF
--- a/packages/sdk/src/transaction/AuroSigner.ts
+++ b/packages/sdk/src/transaction/AuroSigner.ts
@@ -7,9 +7,16 @@ import { Signer } from "./InMemorySigner";
 @injectable()
 export class AuroSigner extends AppChainModule<unknown> implements Signer {
   public async sign(message: Field[]): Promise<Signature> {
+    try {
     const response = await (window as any).mina.signFields({
       message: message.map((field) => field.toString()),
     });
     return Signature.fromBase58(response.signature);
-  }
+  } catch (e: any) {
+    if (e.code == 1001) {
+      await (window as any).mina.requestAccounts();
+      return await this.sign(message);
+    }
+    throw e;
+  }}
 }

--- a/packages/sdk/src/transaction/AuroSigner.ts
+++ b/packages/sdk/src/transaction/AuroSigner.ts
@@ -13,7 +13,7 @@ export class AuroSigner extends AppChainModule<unknown> implements Signer {
     });
     return Signature.fromBase58(response.signature);
   } catch (e: any) {
-    if (e.code == 1001) {
+    if (e?.code == 1001) {
       await (window as any).mina.requestAccounts();
       return await this.sign(message);
     }


### PR DESCRIPTION
Made signer to work with shim connection approach where wallet address is stored on frontend. That allows not to trigger the wallet all the times to get address. However this way requestAccount call is required before signing. The check is added here