### PR TITLE
Fixed error for 0-length runtime args

### DIFF
--- a/packages/module/src/method/runtimeMethod.ts
+++ b/packages/module/src/method/runtimeMethod.ts
@@ -112,11 +112,7 @@ export function toWrappedMethod(
     ).encode(args);
 
     // Assert that the argsHash that has been signed matches the given arguments
-    // We can use js-if here, because args are statically sized
-    // i.e. the result of the if-statement will be the same for all executions
-    // of this method
-    const argsHash =
-      (args ?? []).length > 0 ? Poseidon.hash(argsFields) : Field(0);
+    const argsHash = Poseidon.hash(argsFields);
 
     transaction.argsHash.assertEquals(
       argsHash,

--- a/packages/sequencer/test/integration/BlockProduction.test.ts
+++ b/packages/sequencer/test/integration/BlockProduction.test.ts
@@ -120,41 +120,6 @@ describe("block production", () => {
     mempool = sequencer.resolve("Mempool");
   });
 
-  it.only("regression - should produce block with no STs emitted", async () => {
-    log.setLevel("TRACE");
-
-    const privateKey = PrivateKey.random();
-
-    const tx = createTransaction({
-      runtime,
-      method: ["NoopRuntime", "emittingNoSTs"],
-      privateKey,
-      args: [],
-      nonce: 0,
-    });
-    console.log(tx.argsHash().toString());
-    console.log(tx.toProtocolTransaction().transaction.argsHash.toString());
-    await mempool.add(tx);
-
-    const block = await blockTrigger.produceBlock();
-
-    expect(block).toBeDefined();
-
-    expect(block!.transactions).toHaveLength(1);
-    expect(block!.transactions[0].status.toBoolean()).toBe(true);
-    expect(block!.transactions[0].statusMessage).toBeUndefined();
-
-    expect(block!.transactions[0].stateTransitions).toHaveLength(0);
-    expect(block!.transactions[0].protocolTransitions).toHaveLength(2);
-
-    const batch = await blockTrigger.produceBatch();
-
-    expect(batch).toBeDefined();
-
-    expect(batch!.bundles).toHaveLength(1);
-    expect(batch!.proof.proof).toBe(MOCK_PROOF);
-  }, 30000);
-
   it("should produce a dummy block proof", async () => {
     expect.assertions(25);
 
@@ -568,4 +533,39 @@ describe("block production", () => {
     expect(newBalance).toBeDefined();
     expect(UInt64.fromFields(newBalance!)).toStrictEqual(UInt64.from(200));
   }, 360_000);
+
+  it("regression - should produce block with no STs emitted", async () => {
+    log.setLevel("TRACE");
+
+    const privateKey = PrivateKey.random();
+
+    const tx = createTransaction({
+      runtime,
+      method: ["NoopRuntime", "emittingNoSTs"],
+      privateKey,
+      args: [],
+      nonce: 0,
+    });
+    console.log(tx.argsHash().toString());
+    console.log(tx.toProtocolTransaction().transaction.argsHash.toString());
+    await mempool.add(tx);
+
+    const block = await blockTrigger.produceBlock();
+
+    expect(block).toBeDefined();
+
+    expect(block!.transactions).toHaveLength(1);
+    expect(block!.transactions[0].status.toBoolean()).toBe(true);
+    expect(block!.transactions[0].statusMessage).toBeUndefined();
+
+    expect(block!.transactions[0].stateTransitions).toHaveLength(0);
+    expect(block!.transactions[0].protocolTransitions).toHaveLength(2);
+
+    const batch = await blockTrigger.produceBatch();
+
+    expect(batch).toBeDefined();
+
+    expect(batch!.bundles).toHaveLength(1);
+    expect(batch!.proof.proof).toBe(MOCK_PROOF);
+  }, 30000);
 });

--- a/packages/sequencer/test/integration/mocks/NoopRuntime.ts
+++ b/packages/sequencer/test/integration/mocks/NoopRuntime.ts
@@ -1,0 +1,10 @@
+import { RuntimeModule, runtimeModule, runtimeMethod } from "@proto-kit/module";
+import { noop } from "@proto-kit/common";
+
+@runtimeModule()
+export class NoopRuntime extends RuntimeModule {
+  @runtimeMethod()
+  public async emittingNoSTs() {
+    noop();
+  }
+}


### PR DESCRIPTION
Closes #70  

Merge #174 first

This PR fixes a bug that occurred when a runtime method had no parameters. 
This was due to a discrepancy in the argshash construction for the transaction objects (and therefore signature) and the in-circuit runtime method re-hashing of the args. The runtime method one defaulted to Field(0) for empty args, whereas the transaction one didn't. Unified to doing `hash([])` for empty args