### PR TITLE
Fixed issue where Mempool endpoints would invoke tx ordering

### DIFF
--- a/packages/sequencer/src/storage/inmemory/InMemoryTransactionStorage.ts
+++ b/packages/sequencer/src/storage/inmemory/InMemoryTransactionStorage.ts
@@ -78,6 +78,14 @@ export class InMemoryTransactionStorage implements TransactionStorage {
       }
     | undefined
   > {
+    const pending = await this.getPendingUserTransactions();
+    const pendingResult = pending.find((tx) => tx.hash().toString() === hash);
+    if (pendingResult !== undefined) {
+      return {
+        transaction: pendingResult,
+      };
+    }
+
     const tipHeight = await this.blockStorage.getCurrentBlockHeight();
     const hashField = Field(hash);
 

--- a/packages/sequencer/src/storage/repositories/TransactionStorage.ts
+++ b/packages/sequencer/src/storage/repositories/TransactionStorage.ts
@@ -5,6 +5,13 @@ export interface TransactionStorage {
 
   getPendingUserTransactions: () => Promise<PendingTransaction[]>;
 
+  /**
+   * Finds a transaction by its hash.
+   * It returns both pending transaction and already included transactions
+   * In case the transaction has been included, it also returns the block hash
+   * and batch number where applicable.
+   * @param hash
+   */
   findTransaction: (hash: string) => Promise<
     | {
         transaction: PendingTransaction;


### PR DESCRIPTION
Also: Made findTransaction() in Inmemory and Prisma TxStorage behave the same