### PR TITLE
Enable Proving: Packaged Worker readiness check into AppChain

### DIFF
--- a/packages/sdk/src/appChain/AppChain.ts
+++ b/packages/sdk/src/appChain/AppChain.ts
@@ -23,6 +23,7 @@ import {
   QueryTransportModule,
   NetworkStateTransportModule,
   DummyStateService,
+  WorkerReadyModule,
 } from "@proto-kit/sequencer";
 import {
   NetworkState,
@@ -341,6 +342,11 @@ export class AppChain<
 
     // this.runtime.start();
     await this.sequencer.start();
+
+    // Wait for readyness for worker-ish configurations
+    await this.sequencer.dependencyContainer
+      .resolve(WorkerReadyModule)
+      .waitForReady();
   }
 }
 /* eslint-enable @typescript-eslint/consistent-type-assertions */

--- a/packages/sequencer/src/index.ts
+++ b/packages/sequencer/src/index.ts
@@ -15,6 +15,7 @@ export * from "./worker/queue/LocalTaskQueue";
 export * from "./worker/worker/FlowTaskWorker";
 export * from "./worker/worker/LocalTaskWorkerModule";
 export * from "./worker/worker/TaskWorkerModule";
+export * from "./worker/worker/WorkerReadyModule";
 export * from "./protocol/baselayer/BaseLayer";
 export * from "./protocol/baselayer/MinaBaseLayer";
 export * from "./protocol/baselayer/NoopBaseLayer";

--- a/packages/sequencer/src/protocol/production/helpers/CompileRegistry.ts
+++ b/packages/sequencer/src/protocol/production/helpers/CompileRegistry.ts
@@ -20,13 +20,18 @@ export class CompileRegistry {
     name: string,
     zkProgram: { compile: () => Promise<CompileArtifact> }
   ) {
+    let newPromise = false;
     if (this.compilationPromises[name] === undefined) {
       log.time(`Compiling ${name}`);
       this.compilationPromises[name] = zkProgram.compile();
-      log.timeEnd.info(`Compiling ${name}`);
+      newPromise = true;
     }
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return (await this.compilationPromises[name]) as CompileArtifact;
+    const result = (await this.compilationPromises[name]) as CompileArtifact;
+    if (newPromise) {
+      log.timeEnd.info(`Compiling ${name}`);
+    }
+    return result;
   }
 
   public async compileSmartContract(
@@ -36,16 +41,22 @@ export class CompileRegistry {
     },
     proofsEnabled: boolean = true
   ) {
+    let newPromise = false;
     if (this.compilationPromises[name] === undefined) {
       if (proofsEnabled) {
         log.time(`Compiling ${name}`);
         this.compilationPromises[name] = contract.compile();
-        log.timeEnd.info(`Compiling ${name}`);
       } else {
         this.compilationPromises[name] = Promise.resolve({});
       }
     }
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return (await this.compilationPromises[name]) as ContractCompileArtifact;
+    const result = (await this.compilationPromises[
+      name
+    ]) as ContractCompileArtifact;
+    if (newPromise) {
+      log.timeEnd.info(`Compiling ${name}`);
+    }
+    return result;
   }
 }

--- a/packages/sequencer/src/worker/worker/WorkerReadyModule.ts
+++ b/packages/sequencer/src/worker/worker/WorkerReadyModule.ts
@@ -1,0 +1,32 @@
+import { injectable } from "tsyringe";
+import { injectOptional } from "@proto-kit/common";
+import { LocalTaskWorkerModule } from "./LocalTaskWorkerModule";
+
+/**
+ * Module to safely wait for the finish of the worker startup
+ * Behaves like a noop for non-worker appchain configurations
+ */
+@injectable()
+export class WorkerReadyModule {
+  public constructor(
+    @injectOptional("LocalTaskWorkerModule")
+    private readonly localTaskWorkerModule:
+      | LocalTaskWorkerModule<any>
+      | undefined
+  ) {}
+
+  public async waitForReady(): Promise<void> {
+    if (this.localTaskWorkerModule !== undefined) {
+      const module = this.localTaskWorkerModule;
+      return new Promise<void>((res, rej) => {
+        module.containerEvents.on("ready", (ready) => {
+          if (ready) {
+            res();
+          } else {
+            rej(new Error("Couldn't get ready"));
+          }
+        });
+      });
+    }
+  }
+}

--- a/packages/sequencer/test/integration/BlockProduction.test.ts
+++ b/packages/sequencer/test/integration/BlockProduction.test.ts
@@ -156,14 +156,6 @@ describe("block production", () => {
       throw e;
     }
 
-    // Await worker readiness
-    await new Promise<boolean>((res) => {
-      app
-        .resolve("Sequencer")
-        .resolve("LocalTaskWorkerModule")
-        .containerEvents.on("ready", res);
-    });
-
     appChain = app;
 
     ({ runtime, sequencer, protocol } = app);

--- a/packages/sequencer/test/integration/Proven.test.ts
+++ b/packages/sequencer/test/integration/Proven.test.ts
@@ -82,15 +82,6 @@ describe("Proven", () => {
         const childContainer = container.createChildContainer();
         await app.start(true, childContainer);
 
-        const ready = await new Promise<boolean>((res) => {
-          app
-            .resolve("Sequencer")
-            .resolve("LocalTaskWorkerModule")
-            .containerEvents.on("ready", res);
-        });
-
-        expect(ready).toBe(true);
-
         test = app.sequencer.dependencyContainer.resolve(BlockTestService);
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
This PR packages the worker readiness into a safe hardcoded modules awaited in appchain.start