### PR TITLE
Fix bug in protocol and flow for merging blocks

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -147,3 +147,5 @@ type NonMethodKeys<Type> = {
   [Key in keyof Type]: Type[Key] extends Function ? never : Key;
 }[keyof Type];
 export type NonMethods<Type> = Pick<Type, NonMethodKeys<Type>>;
+
+export const MAX_FIELD = Field(Field.ORDER - 1n);

--- a/packages/protocol/src/prover/block/BlockProvable.ts
+++ b/packages/protocol/src/prover/block/BlockProvable.ts
@@ -24,6 +24,7 @@ export class BlockProverPublicInput extends Struct({
   blockHashRoot: Field,
   eternalTransactionsHash: Field,
   incomingMessagesHash: Field,
+  blockNumber: Field,
 }) {}
 
 export class BlockProverPublicOutput extends Struct({
@@ -36,15 +37,10 @@ export class BlockProverPublicOutput extends Struct({
   closed: Bool,
   blockNumber: Field,
 }) {
-  public equals(
-    input: BlockProverPublicInput,
-    closed: Bool,
-    blockNumber: Field
-  ): Bool {
+  public equals(input: BlockProverPublicInput, closed: Bool): Bool {
     const output2 = BlockProverPublicOutput.toFields({
       ...input,
       closed,
-      blockNumber,
     });
     const output1 = BlockProverPublicOutput.toFields(this);
     return output1

--- a/packages/sequencer/src/protocol/production/TransactionTraceService.ts
+++ b/packages/sequencer/src/protocol/production/TransactionTraceService.ts
@@ -10,7 +10,7 @@ import {
   StateTransitionProverPublicInput,
   StateTransitionType,
 } from "@proto-kit/protocol";
-import { RollupMerkleTree } from "@proto-kit/common";
+import { MAX_FIELD, RollupMerkleTree } from "@proto-kit/common";
 import { Bool, Field } from "o1js";
 import chunk from "lodash/chunk";
 
@@ -133,6 +133,7 @@ export class TransactionTraceService {
       blockHashRoot: block.block.fromBlockHashRoot,
       eternalTransactionsHash: block.block.fromEternalTransactionsHash,
       incomingMessagesHash: block.block.fromMessagesHash,
+      blockNumber: block.block.height,
     });
 
     return {
@@ -241,6 +242,7 @@ export class TransactionTraceService {
           incomingMessagesHash,
           networkStateHash: networkState.hash(),
           blockHashRoot: Field(0),
+          blockNumber: MAX_FIELD,
         },
 
         executionData: {

--- a/packages/sequencer/test/integration/BlockProduction.test.ts
+++ b/packages/sequencer/test/integration/BlockProduction.test.ts
@@ -473,10 +473,17 @@ describe("block production", () => {
     [1, 2, 1],
     [1, 1, 2],
     [2, 2, 2],
+    [1, 14, 0],
   ])(
     "should produce multiple blocks with multiple batches with multiple transactions",
     async (batches, blocksPerBatch, txsPerBlock) => {
-      expect.assertions(2 * batches + 3 * batches * blocksPerBatch);
+      expect.assertions(
+        2 * batches +
+          1 * batches * blocksPerBatch +
+          2 * batches * blocksPerBatch * txsPerBlock
+      );
+
+      log.setLevel("DEBUG");
 
       const sender = PrivateKey.random();
 
@@ -511,8 +518,11 @@ describe("block production", () => {
           const block = await blockTrigger.produceBlock();
 
           expect(block).toBeDefined();
-          expect(block!.transactions).toHaveLength(txsPerBlock);
-          expect(block!.transactions[0].status.toBoolean()).toBe(true);
+
+          for (let k = 0; k < txsPerBlock; k++) {
+            expect(block!.transactions).toHaveLength(txsPerBlock);
+            expect(block!.transactions[0].status.toBoolean()).toBe(true);
+          }
         }
 
         const batch = await blockTrigger.produceBatch();


### PR DESCRIPTION
Previously, if there were more than 2 blocks in a batch, the block merging flow would halt because it couldn't find any more matches. This was because we only exposed the blockNumber as public output, therefore as soon as we merged blocks n+1 and n+2, the next merge (n and this block) couldn't find a match because n + 1 != n + 2.

The fix adds a "from" blockNumber to the publicInput and therefore allows corrected stitching.