### PR TITLE
Fix for Mempool and BP using different State Services

### DIFF
--- a/packages/common/src/config/ModuleContainer.ts
+++ b/packages/common/src/config/ModuleContainer.ts
@@ -4,7 +4,7 @@ import {
   DependencyContainer,
   Frequency,
   InjectionToken,
-  instancePerContainerCachingFactory,
+  instanceCachingFactory,
   isClassProvider,
   isFactoryProvider,
   isTokenProvider,
@@ -404,9 +404,7 @@ export class ModuleContainer<
           // this enables us to have a singletoned factory
           // that returns the same instance for each resolve
           this.container.register(key, {
-            useFactory: instancePerContainerCachingFactory(
-              declaration.useFactory
-            ),
+            useFactory: instanceCachingFactory(declaration.useFactory),
           });
         } else if (isClassProvider(declaration)) {
           this.container.register(key, declaration, {

--- a/packages/sequencer/test/integration/BlockProduction.test.ts
+++ b/packages/sequencer/test/integration/BlockProduction.test.ts
@@ -337,6 +337,107 @@ describe("block production", () => {
     expect(newState).toBeUndefined();
   }, 30_000);
 
+  it("should produce txs in non-consecutive blocks", async () => {
+    log.setLevel("TRACE");
+
+    const privateKey = PrivateKey.random();
+    const publicKey = privateKey.toPublicKey();
+
+    const privateKey2 = PrivateKey.random();
+    const publicKey2 = privateKey2.toPublicKey();
+
+    await mempool.add(
+      createTransaction({
+        runtime,
+        method: ["Balance", "setBalanceIf"],
+        privateKey,
+        args: [publicKey, UInt64.from(100), Bool(true)],
+        nonce: 0,
+      })
+    );
+
+    // let [block, batch] = await blockTrigger.produceBlockAndBatch();
+    const block = await blockTrigger.produceBlock();
+
+    expect(block).toBeDefined();
+
+    expect(block!.transactions).toHaveLength(1);
+    expect(block!.transactions[0].status.toBoolean()).toBe(true);
+    expect(block!.transactions[0].statusMessage).toBeUndefined();
+
+    expect(block!.transactions[0].stateTransitions).toHaveLength(1);
+    expect(block!.transactions[0].protocolTransitions).toHaveLength(2);
+
+    await blockTrigger.produceBlock();
+
+    await mempool.add(
+      createTransaction({
+        runtime,
+        method: ["Balance", "setBalanceIf"],
+        privateKey: privateKey2,
+        args: [publicKey2, UInt64.from(100), Bool(true)],
+        nonce: 0,
+      })
+    );
+    await blockTrigger.produceBlock();
+
+    await mempool.add(
+      createTransaction({
+        runtime,
+        method: ["Balance", "setBalanceIf"],
+        privateKey: privateKey2,
+        args: [publicKey2, UInt64.from(100), Bool(true)],
+        nonce: 1,
+      })
+    );
+    await blockTrigger.produceBlock();
+
+    await mempool.add(
+      createTransaction({
+        runtime,
+        method: ["Balance", "setBalanceIf"],
+        privateKey: privateKey2,
+        args: [publicKey2, UInt64.from(100), Bool(true)],
+        nonce: 2,
+      })
+    );
+    await blockTrigger.produceBlock();
+
+    await mempool.add(
+      createTransaction({
+        runtime,
+        method: ["Balance", "setBalanceIf"],
+        privateKey: privateKey2,
+        args: [publicKey2, UInt64.from(100), Bool(true)],
+        nonce: 3,
+      })
+    );
+    await blockTrigger.produceBlock();
+
+    // Second tx
+    await mempool.add(
+      createTransaction({
+        runtime,
+        method: ["Balance", "setBalanceIf"],
+        privateKey,
+        args: [publicKey, UInt64.from(100), Bool(true)],
+        nonce: 1,
+      })
+    );
+
+    log.info("Starting second block");
+
+    const block2 = await blockTrigger.produceBlock();
+
+    expect(block2).toBeDefined();
+
+    expect(block2!.transactions).toHaveLength(1);
+    console.log(block2!.transactions[0]);
+    console.log(block2!.transactions[0].statusMessage);
+    expect(block2!.transactions[0].status.toBoolean()).toBe(true);
+    expect(block2!.transactions[0].statusMessage).toBeUndefined();
+  }, 60_000);
+
   const numberTxs = 3;
 
   it("should produce block with multiple transaction", async () => {


### PR DESCRIPTION
A community member reported seeing an issue where a tx was stuck in pending, i.e. never included in a block. This was because when a block is produced it checks to see if a tx is valid, which involves checking the nonce (amongst other things). A previous tx had already been sent from the same sender, but this was not being noticed by the BP and so expected the tx in the mempool to have nonce 0, rather the the correct nonce of 1, which it in fact had. Consequently, the tx was never picked up and just sat there in the mempool.