### PR TITLE
Record resolving order in the sequencer and start modules based on that

### DIFF
--- a/packages/sequencer/src/sequencer/executor/Sequencer.ts
+++ b/packages/sequencer/src/sequencer/executor/Sequencer.ts
@@ -66,6 +66,14 @@ export class Sequencer<Modules extends SequencerModulesRecord>
    * modules to start each
    */
   public async start() {
+    // The sequencer uses Tysringe to resolve modules (and their dependencies)
+    // and then starts them. However, this can be problematic as although Tysringe may resolve
+    // dependencies, it doesn't actually start them. For example, a database may be created,
+    // but the connection strings, etc, won't be constructed until it's started, and this may
+    // cause an error if a module that relies on it is started first. The way to fix this is
+    // ensure that we start modules based on the order they were resolved.
+    // We iterate through the methods three times:
+
     this.useDependencyFactory(this.container.resolve(MethodIdFactory));
 
     // Log startup info
@@ -75,6 +83,8 @@ export class Sequencer<Modules extends SequencerModulesRecord>
     log.info("Starting sequencer...");
     log.info("Modules:", moduleClassNames);
 
+    // Iteration #1: We invoke the afterResolution feature for the container
+    // to ensure every time a module is resolved it gets recorded.
     const orderedModules: Extract<keyof Modules, string>[] = [];
     // eslint-disable-next-line guard-for-in
     for (const moduleName in this.definition.modules) {
@@ -88,6 +98,8 @@ export class Sequencer<Modules extends SequencerModulesRecord>
         }
       );
     }
+    // Iteration #2: We resolve each module and thus populate
+    // the orderedModules list to understand the sequencing.
     // eslint-disable-next-line guard-for-in
     for (const moduleName in this.definition.modules) {
       const sequencerModule = this.resolve(moduleName);
@@ -96,6 +108,8 @@ export class Sequencer<Modules extends SequencerModulesRecord>
       );
     }
 
+    // Iteration #3: We now iterate though the orderedModules list
+    // and start the modules in the order they were resolved.
     for (const moduleName of orderedModules) {
       const sequencerModule = this.resolve(moduleName);
       // eslint-disable-next-line no-await-in-loop

--- a/packages/sequencer/src/sequencer/executor/Sequencer.ts
+++ b/packages/sequencer/src/sequencer/executor/Sequencer.ts
@@ -75,6 +75,19 @@ export class Sequencer<Modules extends SequencerModulesRecord>
     log.info("Starting sequencer...");
     log.info("Modules:", moduleClassNames);
 
+    const orderedModules: Extract<keyof Modules, string>[] = [];
+    // eslint-disable-next-line guard-for-in
+    for (const moduleName in this.definition.modules) {
+      this.container.afterResolution(
+        moduleName,
+        () => {
+          orderedModules.push(moduleName);
+        },
+        {
+          frequency: "Once",
+        }
+      );
+    }
     // eslint-disable-next-line guard-for-in
     for (const moduleName in this.definition.modules) {
       const sequencerModule = this.resolve(moduleName);
@@ -82,6 +95,10 @@ export class Sequencer<Modules extends SequencerModulesRecord>
       log.info(
         `Starting sequencer module ${moduleName} (${sequencerModule.constructor.name})`
       );
+    }
+
+    for (const moduleName of orderedModules) {
+      const sequencerModule = this.resolve(moduleName);
       // eslint-disable-next-line no-await-in-loop
       await sequencerModule.start();
     }

--- a/packages/sequencer/src/sequencer/executor/Sequencer.ts
+++ b/packages/sequencer/src/sequencer/executor/Sequencer.ts
@@ -66,8 +66,8 @@ export class Sequencer<Modules extends SequencerModulesRecord>
    * modules to start each
    */
   public async start() {
-    // The sequencer uses Tysringe to resolve modules (and their dependencies)
-    // and then starts them. However, this can be problematic as although Tysringe may resolve
+    // The sequencer uses tsyringe to resolve modules (and their dependencies)
+    // and then starts them. However, this can be problematic as although tsyringe may resolve
     // dependencies, it doesn't actually start them. For example, a database may be created,
     // but the connection strings, etc, won't be constructed until it's started, and this may
     // cause an error if a module that relies on it is started first. The way to fix this is

--- a/packages/sequencer/src/sequencer/executor/Sequencer.ts
+++ b/packages/sequencer/src/sequencer/executor/Sequencer.ts
@@ -91,9 +91,8 @@ export class Sequencer<Modules extends SequencerModulesRecord>
     // eslint-disable-next-line guard-for-in
     for (const moduleName in this.definition.modules) {
       const sequencerModule = this.resolve(moduleName);
-
       log.info(
-        `Starting sequencer module ${moduleName} (${sequencerModule.constructor.name})`
+        `Resolving sequencer module ${moduleName} (${sequencerModule.constructor.name})`
       );
     }
 
@@ -101,6 +100,10 @@ export class Sequencer<Modules extends SequencerModulesRecord>
       const sequencerModule = this.resolve(moduleName);
       // eslint-disable-next-line no-await-in-loop
       await sequencerModule.start();
+
+      log.info(
+        `Starting sequencer module ${moduleName} (${sequencerModule.constructor.name})`
+      );
     }
   }
 }


### PR DESCRIPTION
Presently, the sequencer uses `tsyringe` to resolve modules (and their dependencies) and then starts them. However, this can be problematic as although `tsyringe` may resolve dependencies, it doesn't actually start them. For example, a database may be created, but the connection strings, etc, won't be constructed until it's started, and this may cause an error if a module that relies on it is started first. The way to resolve this is ensure that we start modules based on the order they were resolved.