### PR TITLE
Refactor injection token definitions for dynamic keys

### DIFF
--- a/packages/protocol/src/protocol/Protocol.ts
+++ b/packages/protocol/src/protocol/Protocol.ts
@@ -27,6 +27,12 @@ import { ProvableTransactionHook } from "./ProvableTransactionHook";
 import { ProtocolEnvironment } from "./ProtocolEnvironment";
 import { ProvableBlockHook } from "./ProvableBlockHook";
 
+/**
+ * This is a mapping of abstract classes to their respective injection tokens.
+ * Keys are the abstract classes names, which need to be set dynamically
+ * and can't be hardcoded since producing optimized builds may mangle the
+ * class names, making them different from the ones in the source code.
+ */
 const PROTOCOL_INJECTION_TOKENS: Record<string, string> = {
   [ProvableTransactionHook.name]: "ProvableTransactionHook",
   [ProvableBlockHook.name]: "ProvableBlockHook",

--- a/packages/protocol/src/protocol/Protocol.ts
+++ b/packages/protocol/src/protocol/Protocol.ts
@@ -28,9 +28,9 @@ import { ProtocolEnvironment } from "./ProtocolEnvironment";
 import { ProvableBlockHook } from "./ProvableBlockHook";
 
 const PROTOCOL_INJECTION_TOKENS: Record<string, string> = {
-  ProvableTransactionHook: "ProvableTransactionHook",
-  ProvableBlockHook: "ProvableBlockHook",
-  ProvableSettlementHook: "ProvableSettlementHook",
+  [ProvableTransactionHook.name]: "ProvableTransactionHook",
+  [ProvableBlockHook.name]: "ProvableBlockHook",
+  [ProvableSettlementHook.name]: "ProvableSettlementHook",
 };
 
 export type ProtocolModulesRecord = ModulesRecord<
@@ -161,7 +161,7 @@ export class Protocol<
 
       implementingModules.forEach(([key]) => {
         this.container.register(
-          abstractType.name,
+          newInjectionToken,
           { useToken: key },
           { lifecycle: Lifecycle.ContainerScoped }
         );
@@ -174,7 +174,7 @@ export class Protocol<
 
         // Register default (noop) version
         this.container.register(
-          abstractType.name,
+          newInjectionToken,
           { useClass: defaultType },
           { lifecycle: Lifecycle.ContainerScoped }
         );


### PR DESCRIPTION
Fixes proto-kit/starter-kit#39, which was caused by some update to Next.js/Webpack on Next.js v15 that would make class names mangled on production builds, rendering in failed dependency injections that relied on the class names. This PR addresses this by setting the keys of the record with the injection tokens to be set to the dynamic value of the class names.