### PR TITLE
Configured jest console outputs to exclude useless stack traces

### DIFF
--- a/console-jest.config.js
+++ b/console-jest.config.js
@@ -1,0 +1,3 @@
+import console from "console";
+
+global.console = console;

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -44,4 +44,5 @@ module.exports = {
       },
     ],
   },
+  setupFilesAfterEnv: ["./console-jest.config.js"],
 };


### PR DESCRIPTION
This PR reformats the outputs of the jest console output from something like

```
console.log
      Foo

      at log.info (packages/common/log/log.ts:34)
```
to
```
Foo
```

Making the outputs more readable and condensed, and therefore test outputs (both locally and in CI) more useful