### PR TITLE
Contract deployment check

### DIFF
--- a/packages/sequencer/src/settlement/SettlementModule.ts
+++ b/packages/sequencer/src/settlement/SettlementModule.ts
@@ -24,6 +24,7 @@ import {
   EventEmittingComponent,
   log,
   DependencyFactory,
+  mapSequential,
 } from "@proto-kit/common";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import truncate from "lodash/truncate";
@@ -359,71 +360,43 @@ export class SettlementModule
       ).bridgeContractMina(),
     };
   }
-
   public async checkDeployment(
     tokenBridges?: Array<{ address: PublicKey; tokenId: Field }>
-  ): Promise<void | never> {
-    const contractAddresses = this.getContractAddresses();
+  ): Promise<void> {
+    const contracts: Array<{ address: PublicKey; tokenId?: Field }> = [
+      ...this.getContractAddresses().map(addr => ({ address: addr })),
+      ...(tokenBridges ?? [])
+    ];
 
-    if (this.baseLayer.config.network.type !== "local") {
-      // Check main contracts
-      await Promise.all(
-        contractAddresses.map(async (pubKey) => {
-          const { account, error } = await fetchAccount({ publicKey: pubKey });
+    const isLocal = this.baseLayer.isLocalBlockChain();
+    const missing: Array<{ address: string; error: string }> = [];
 
-          if (!account) {
-            let message = `Account ${pubKey.toBase58()} not found on chain`;
-
-            if (error !== undefined) {
-              message += `: ${error.statusText}`;
-            }
-
-            throw new Error(message);
-          }
-        })
-      );
-
-      // Check token bridges with their tokenIds
-      if (tokenBridges) {
-        await Promise.all(
-          tokenBridges.map(async ({ address, tokenId }) => {
-            const { account, error } = await fetchAccount({
-              publicKey: address,
-              tokenId,
-            });
-
-            if (!account) {
-              let message = `Account ${address.toBase58()} not found on chain`;
-
-              if (error !== undefined) {
-                message += `: ${error.statusText}`;
-              }
-
-              throw new Error(message);
-            }
-          })
-        );
-      }
-    } else {
-      // Local network
-      contractAddresses.forEach((pubKey) => {
-        if (!Mina.hasAccount(pubKey)) {
-          throw new Error(
-            `Contract ${pubKey.toBase58()} not found on local chain`
-          );
-        }
-      });
-
-      // Check token bridges
-      if (tokenBridges) {
-        tokenBridges.forEach(({ address, tokenId }) => {
+    await Promise.all(
+      contracts.map(async ({ address, tokenId }) => {
+        if (isLocal) {
           if (!Mina.hasAccount(address, tokenId)) {
-            throw new Error(
-              `Token bridge ${address.toBase58()} @ ${tokenId.toString()} not found`
-            );
+            missing.push({
+              address: address.toBase58(),
+              error: 'Not found on local chain'
+            });
           }
-        });
-      }
+        } else {
+          const { account, error } = await fetchAccount({ publicKey: address, tokenId });
+          if (!account) {
+            missing.push({
+              address: address.toBase58(),
+              error: error?.statusText ?? 'Not found on chain'
+            });
+          }
+        }
+      })
+    );
+
+    if (missing.length) {
+      const errorList = missing.map(m => `  ${m.address}: ${m.error}`).join('\n');
+      throw new Error(`
+        Missing contracts:\n${errorList}
+        `);
     }
   }
 }

--- a/packages/sequencer/src/settlement/SettlementModule.ts
+++ b/packages/sequencer/src/settlement/SettlementModule.ts
@@ -385,7 +385,7 @@ export class SettlementModule
             publicKey: address,
             tokenId,
           });
-          if (!account) {
+          if (account === null || account === undefined) {
             missing.push({
               address: address.toBase58(),
               error: error?.statusText ?? "Not found on chain",
@@ -395,7 +395,7 @@ export class SettlementModule
       })
     );
 
-    if (missing.length) {
+    if (missing.length > 0) {
       const errorList = missing
         .map((m) => `  ${m.address}: ${m.error}`)
         .join("\n");

--- a/packages/sequencer/src/settlement/SettlementModule.ts
+++ b/packages/sequencer/src/settlement/SettlementModule.ts
@@ -9,7 +9,15 @@ import {
   SettlementSmartContractBase,
   DynamicBlockProof,
 } from "@proto-kit/protocol";
-import { AccountUpdate, fetchAccount, Field, Mina, PublicKey, TokenContract, TokenId } from "o1js";
+import {
+  AccountUpdate,
+  fetchAccount,
+  Field,
+  Mina,
+  PublicKey,
+  TokenContract,
+  TokenId,
+} from "o1js";
 import { inject } from "tsyringe";
 import {
   EventEmitter,
@@ -351,53 +359,71 @@ export class SettlementModule
       ).bridgeContractMina(),
     };
   }
-  
+
   public async checkDeployment(
-  tokenBridges?: Array<{ address: PublicKey; tokenId: Field }>
-): Promise<void | never> {
-  const contractAddresses = this.getContractAddresses();
-  
-  if (this.baseLayer.config.network.type !== 'local') {
-    // Check main contracts
-    await Promise.all(
-      contractAddresses.map(async (pubKey) => {
-        const { account, error } = await fetchAccount({ publicKey: pubKey });
-        if (!account || !!error) {
-          throw new Error(`Error finding account ${pubKey.toBase58()}`);
-        }
-      })
-    );
-    
-    // Check token bridges with their tokenIds
-    if (tokenBridges) {
+    tokenBridges?: Array<{ address: PublicKey; tokenId: Field }>
+  ): Promise<void | never> {
+    const contractAddresses = this.getContractAddresses();
+
+    if (this.baseLayer.config.network.type !== "local") {
+      // Check main contracts
       await Promise.all(
-        tokenBridges.map(async ({ address, tokenId }) => {
-          const { account, error } = await fetchAccount({ 
-            publicKey: address, 
-            tokenId 
-          });
-          if (!account || !!error) {
-            throw new Error(`Error finding token bridge ${address.toBase58()} @ ${tokenId.toString()}`);
+        contractAddresses.map(async (pubKey) => {
+          const { account, error } = await fetchAccount({ publicKey: pubKey });
+
+          if (!account) {
+            let message = `Account ${pubKey.toBase58()} not found on chain`;
+
+            if (error !== undefined) {
+              message += `: ${error.statusText}`;
+            }
+
+            throw new Error(message);
           }
         })
       );
-    }
-  } else {
-    // Local network
-    contractAddresses.forEach((pubKey) => {
-      if (!Mina.hasAccount(pubKey)) {
-        throw new Error(`Contract ${pubKey.toBase58()} not found on local chain`);
+
+      // Check token bridges with their tokenIds
+      if (tokenBridges) {
+        await Promise.all(
+          tokenBridges.map(async ({ address, tokenId }) => {
+            const { account, error } = await fetchAccount({
+              publicKey: address,
+              tokenId,
+            });
+
+            if (!account) {
+              let message = `Account ${address.toBase58()} not found on chain`;
+
+              if (error !== undefined) {
+                message += `: ${error.statusText}`;
+              }
+
+              throw new Error(message);
+            }
+          })
+        );
       }
-    });
-    
-    // Check token bridges
-    if (tokenBridges) {
-      tokenBridges.forEach(({ address, tokenId }) => {
-        if (!Mina.hasAccount(address, tokenId)) {
-          throw new Error(`Token bridge ${address.toBase58()} @ ${tokenId.toString()} not found`);
+    } else {
+      // Local network
+      contractAddresses.forEach((pubKey) => {
+        if (!Mina.hasAccount(pubKey)) {
+          throw new Error(
+            `Contract ${pubKey.toBase58()} not found on local chain`
+          );
         }
       });
+
+      // Check token bridges
+      if (tokenBridges) {
+        tokenBridges.forEach(({ address, tokenId }) => {
+          if (!Mina.hasAccount(address, tokenId)) {
+            throw new Error(
+              `Token bridge ${address.toBase58()} @ ${tokenId.toString()} not found`
+            );
+          }
+        });
+      }
     }
   }
-}
 }

--- a/packages/sequencer/src/settlement/SettlementModule.ts
+++ b/packages/sequencer/src/settlement/SettlementModule.ts
@@ -9,7 +9,7 @@ import {
   SettlementSmartContractBase,
   DynamicBlockProof,
 } from "@proto-kit/protocol";
-import { AccountUpdate, Mina, PublicKey, TokenContract, TokenId } from "o1js";
+import { AccountUpdate, fetchAccount, Mina, PublicKey, TokenContract, TokenId } from "o1js";
 import { inject } from "tsyringe";
 import {
   EventEmitter,
@@ -351,4 +351,37 @@ export class SettlementModule
       ).bridgeContractMina(),
     };
   }
+  
+  public async checkDeployment(): Promise<void | never> {
+  const network = this.baseLayer.network;
+  if (!network) {
+    throw new Error('Network is not found!?');
+  }
+  
+  const accountAddresses = this.getContractAddresses().concat(
+    // Add token bridge addresses, if exists
+    this.signer.getTokenAddresses()
+  );
+  
+  if (this.baseLayer.config.network.type !== 'local') {
+    // Use Promise.all with map instead of forEach
+    await Promise.all(
+      accountAddresses.map(async (pubKey) => {
+        const { account, error } = await fetchAccount({ publicKey: pubKey.toBase58() });
+        if (!account || !!error) {
+          throw new Error(`Error finding account ${pubKey.toBase58()} on chain`);
+        }
+      })
+    );
+  } else {
+    await Promise.all(
+      accountAddresses.map(async (pubKey) => {
+        const account_exists = Mina.hasAccount(pubKey);
+        if (!account_exists) {
+          throw new Error(`Error finding account ${pubKey.toBase58()} on local chain`);
+        }
+      })
+    );
+  }
+}
 }

--- a/packages/sequencer/src/settlement/SettlementModule.ts
+++ b/packages/sequencer/src/settlement/SettlementModule.ts
@@ -24,7 +24,6 @@ import {
   EventEmittingComponent,
   log,
   DependencyFactory,
-  mapSequential,
 } from "@proto-kit/common";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import truncate from "lodash/truncate";
@@ -360,12 +359,13 @@ export class SettlementModule
       ).bridgeContractMina(),
     };
   }
+
   public async checkDeployment(
     tokenBridges?: Array<{ address: PublicKey; tokenId: Field }>
   ): Promise<void> {
     const contracts: Array<{ address: PublicKey; tokenId?: Field }> = [
-      ...this.getContractAddresses().map(addr => ({ address: addr })),
-      ...(tokenBridges ?? [])
+      ...this.getContractAddresses().map((addr) => ({ address: addr })),
+      ...(tokenBridges ?? []),
     ];
 
     const isLocal = this.baseLayer.isLocalBlockChain();
@@ -377,15 +377,18 @@ export class SettlementModule
           if (!Mina.hasAccount(address, tokenId)) {
             missing.push({
               address: address.toBase58(),
-              error: 'Not found on local chain'
+              error: "Not found on local chain",
             });
           }
         } else {
-          const { account, error } = await fetchAccount({ publicKey: address, tokenId });
+          const { account, error } = await fetchAccount({
+            publicKey: address,
+            tokenId,
+          });
           if (!account) {
             missing.push({
               address: address.toBase58(),
-              error: error?.statusText ?? 'Not found on chain'
+              error: error?.statusText ?? "Not found on chain",
             });
           }
         }
@@ -393,7 +396,9 @@ export class SettlementModule
     );
 
     if (missing.length) {
-      const errorList = missing.map(m => `  ${m.address}: ${m.error}`).join('\n');
+      const errorList = missing
+        .map((m) => `  ${m.address}: ${m.error}`)
+        .join("\n");
       throw new Error(`
         Missing contracts:\n${errorList}
         `);

--- a/packages/sequencer/src/settlement/SettlementModule.ts
+++ b/packages/sequencer/src/settlement/SettlementModule.ts
@@ -9,7 +9,7 @@ import {
   SettlementSmartContractBase,
   DynamicBlockProof,
 } from "@proto-kit/protocol";
-import { AccountUpdate, fetchAccount, Mina, PublicKey, TokenContract, TokenId } from "o1js";
+import { AccountUpdate, fetchAccount, Field, Mina, PublicKey, TokenContract, TokenId } from "o1js";
 import { inject } from "tsyringe";
 import {
   EventEmitter,
@@ -352,36 +352,52 @@ export class SettlementModule
     };
   }
   
-  public async checkDeployment(): Promise<void | never> {
-  const network = this.baseLayer.network;
-  if (!network) {
-    throw new Error('Network is not found!?');
-  }
-  
-  const accountAddresses = this.getContractAddresses().concat(
-    // Add token bridge addresses, if exists
-    this.signer.getTokenAddresses()
-  );
+  public async checkDeployment(
+  tokenBridges?: Array<{ address: PublicKey; tokenId: Field }>
+): Promise<void | never> {
+  const contractAddresses = this.getContractAddresses();
   
   if (this.baseLayer.config.network.type !== 'local') {
-    // Use Promise.all with map instead of forEach
+    // Check main contracts
     await Promise.all(
-      accountAddresses.map(async (pubKey) => {
-        const { account, error } = await fetchAccount({ publicKey: pubKey.toBase58() });
+      contractAddresses.map(async (pubKey) => {
+        const { account, error } = await fetchAccount({ publicKey: pubKey });
         if (!account || !!error) {
-          throw new Error(`Error finding account ${pubKey.toBase58()} on chain`);
+          throw new Error(`Error finding account ${pubKey.toBase58()}`);
         }
       })
     );
+    
+    // Check token bridges with their tokenIds
+    if (tokenBridges) {
+      await Promise.all(
+        tokenBridges.map(async ({ address, tokenId }) => {
+          const { account, error } = await fetchAccount({ 
+            publicKey: address, 
+            tokenId 
+          });
+          if (!account || !!error) {
+            throw new Error(`Error finding token bridge ${address.toBase58()} @ ${tokenId.toString()}`);
+          }
+        })
+      );
+    }
   } else {
-    await Promise.all(
-      accountAddresses.map(async (pubKey) => {
-        const account_exists = Mina.hasAccount(pubKey);
-        if (!account_exists) {
-          throw new Error(`Error finding account ${pubKey.toBase58()} on local chain`);
+    // Local network
+    contractAddresses.forEach((pubKey) => {
+      if (!Mina.hasAccount(pubKey)) {
+        throw new Error(`Contract ${pubKey.toBase58()} not found on local chain`);
+      }
+    });
+    
+    // Check token bridges
+    if (tokenBridges) {
+      tokenBridges.forEach(({ address, tokenId }) => {
+        if (!Mina.hasAccount(address, tokenId)) {
+          throw new Error(`Token bridge ${address.toBase58()} @ ${tokenId.toString()} not found`);
         }
-      })
-    );
+      });
+    }
   }
 }
 }

--- a/packages/sequencer/test/settlement/Settlement.test.ts
+++ b/packages/sequencer/test/settlement/Settlement.test.ts
@@ -13,6 +13,15 @@ describe.each(["mock-proofs", "signed"] as const)(
       },
     };
 
+    const localNetwork: MinaBaseLayerConfig = {
+      network: {
+        type:'lightnet',
+        archive:'http://127.0.0.1:8282',
+        accountManager:'http://127.0.0.1:8181',
+        graphql: 'http://127.0.0.1:8080/graphql',
+      }
+    }
+
     describe("Default token", () => {
       settlementTestFn(type, network);
     });
@@ -21,6 +30,10 @@ describe.each(["mock-proofs", "signed"] as const)(
       settlementTestFn(type, network, {
         tokenOwner: FungibleToken,
       });
+    });
+    
+    describe("Default token in lightnet", () => {
+      settlementTestFn(type,localNetwork);
     });
   }
 );

--- a/packages/sequencer/test/settlement/Settlement.test.ts
+++ b/packages/sequencer/test/settlement/Settlement.test.ts
@@ -13,15 +13,6 @@ describe.each(["mock-proofs", "signed"] as const)(
       },
     };
 
-    const localNetwork: MinaBaseLayerConfig = {
-      network: {
-        type:'lightnet',
-        archive:'http://127.0.0.1:8282',
-        accountManager:'http://127.0.0.1:8181',
-        graphql: 'http://127.0.0.1:8080/graphql',
-      }
-    }
-
     describe("Default token", () => {
       settlementTestFn(type, network);
     });
@@ -30,10 +21,6 @@ describe.each(["mock-proofs", "signed"] as const)(
       settlementTestFn(type, network, {
         tokenOwner: FungibleToken,
       });
-    });
-    
-    describe("Default token in lightnet", () => {
-      settlementTestFn(type,localNetwork);
     });
   }
 );

--- a/packages/sequencer/test/settlement/Settlement.ts
+++ b/packages/sequencer/test/settlement/Settlement.ts
@@ -312,6 +312,10 @@ export const settlementTestFn = (
   let user0Nonce = 0;
   let acc0L2Nonce = 0;
 
+  it("should throw error", async () => {
+    await expect(settlementModule.checkDeployment()).rejects.toThrow();
+  });
+
   it(
     "should deploy",
     async () => {
@@ -331,6 +335,11 @@ export const settlementTestFn = (
     },
     timeout * 2
   );
+
+  it("should not throw error", async () => {
+    // If it doesn't throw anything, it indicates that deployment checs were succesful. 
+    await settlementModule.checkDeployment();
+  });
 
   if (tokenConfig !== undefined) {
     it(

--- a/packages/sequencer/test/settlement/Settlement.ts
+++ b/packages/sequencer/test/settlement/Settlement.ts
@@ -705,9 +705,10 @@ export const settlementTestFn = (
       expect(settlementResult.bridgeTransactions).toHaveLength(2);
 
       await settlementModule.utils.fetchContractAccounts({
-          address: userKey.toPublicKey(),
-          tokenId: bridgingContract.deriveTokenId(),
-        });
+        address: userKey.toPublicKey(),
+        tokenId: bridgingContract.deriveTokenId(),
+      });
+
       const account = Mina.getAccount(
         userKey.toPublicKey(),
         bridgingContract.deriveTokenId()
@@ -801,17 +802,17 @@ export const settlementTestFn = (
 
   it("should not throw error after settlement", async () => {
     expect.assertions(1);
-    
+
     // Obtain promise of deployment check
-    const deploymentCheckPromise = tokenConfig === undefined ? 
-                settlementModule.checkDeployment() 
-                :
-                settlementModule.checkDeployment([
-                  {
-                    address: tokenBridgeKey.toPublicKey(),
-                    tokenId: tokenOwner!.deriveTokenId(),
-                  },
-                ])
+    const deploymentCheckPromise =
+      tokenConfig === undefined
+        ? settlementModule.checkDeployment()
+        : settlementModule.checkDeployment([
+            {
+              address: tokenBridgeKey.toPublicKey(),
+              tokenId: tokenOwner!.deriveTokenId(),
+            },
+          ]);
 
     await expect(deploymentCheckPromise).resolves.toBeUndefined();
   });

--- a/packages/sequencer/test/settlement/Settlement.ts
+++ b/packages/sequencer/test/settlement/Settlement.ts
@@ -704,12 +704,10 @@ export const settlementTestFn = (
 
       expect(settlementResult.bridgeTransactions).toHaveLength(2);
 
-      if (baseLayerConfig.network.type !== "local") {
-        await fetchAccount({
-          publicKey: userKey.toPublicKey(),
+      settlementModule.utils.fetchContractAccounts({
+          address: userKey.toPublicKey(),
           tokenId: bridgingContract.deriveTokenId(),
         });
-      }
       const account = Mina.getAccount(
         userKey.toPublicKey(),
         bridgingContract.deriveTokenId()
@@ -802,16 +800,19 @@ export const settlementTestFn = (
   );
 
   it("should not throw error after settlement", async () => {
-    // If it doesn't throw anything, it indicates that deployment checs were succesful.
-    if (tokenConfig === undefined) {
-      await settlementModule.checkDeployment();
-    } else {
-      await settlementModule.checkDeployment([
-        {
-          address: tokenBridgeKey.toPublicKey(),
-          tokenId: tokenOwner!.deriveTokenId(),
-        },
-      ]);
-    }
+    expect.assertions(1);
+    
+    // Obtain promise of deployment check
+    const deploymentCheckPromise = tokenConfig === undefined ? 
+                settlementModule.checkDeployment() 
+                :
+                settlementModule.checkDeployment([
+                  {
+                    address: tokenBridgeKey.toPublicKey(),
+                    tokenId: tokenOwner!.deriveTokenId(),
+                  },
+                ])
+
+    await expect(deploymentCheckPromise).resolves.toBeUndefined();
   });
 };

--- a/packages/sequencer/test/settlement/Settlement.ts
+++ b/packages/sequencer/test/settlement/Settlement.ts
@@ -313,14 +313,16 @@ export const settlementTestFn = (
   let acc0L2Nonce = 0;
 
   it("should throw error", async () => {
-    
-    const deploymentPromise = tokenConfig === undefined
-      ? settlementModule.checkDeployment()
-      : settlementModule.checkDeployment([{
-          address: tokenBridgeKey.toPublicKey(),
-          tokenId: tokenOwner!.deriveTokenId()
-        }]);
-  
+    const deploymentPromise =
+      tokenConfig === undefined
+        ? settlementModule.checkDeployment()
+        : settlementModule.checkDeployment([
+            {
+              address: tokenBridgeKey.toPublicKey(),
+              tokenId: tokenOwner!.deriveTokenId(),
+            },
+          ]);
+
     await expect(deploymentPromise).rejects.toThrow();
   });
 
@@ -591,11 +593,11 @@ export const settlementTestFn = (
 
         const actions = await Mina.fetchActions(dispatch.address);
         if (baseLayerConfig.network.type !== "local") {
-        await fetchAccount({
-          publicKey: tokenBridgeKey.toPublicKey(),
-          tokenId: bridgedTokenId
-        });
-       }
+          await fetchAccount({
+            publicKey: tokenBridgeKey.toPublicKey(),
+            tokenId: bridgedTokenId,
+          });
+        }
         const balanceDiff = bridge.account.balance
           .get()
           .sub(contractBalanceBefore);
@@ -800,17 +802,15 @@ export const settlementTestFn = (
   );
 
   it("should not throw error after settlement", async () => {
-    // If it doesn't throw anything, it indicates that deployment checs were succesful. 
-    if(tokenConfig === undefined)
-    {
-    await settlementModule.checkDeployment();  
-    }
-    else{
-    await settlementModule.checkDeployment([
+    // If it doesn't throw anything, it indicates that deployment checs were succesful.
+    if (tokenConfig === undefined) {
+      await settlementModule.checkDeployment();
+    } else {
+      await settlementModule.checkDeployment([
         {
           address: tokenBridgeKey.toPublicKey(),
-          tokenId: tokenOwner!.deriveTokenId()
-        }
+          tokenId: tokenOwner!.deriveTokenId(),
+        },
       ]);
     }
   });

--- a/packages/sequencer/test/settlement/Settlement.ts
+++ b/packages/sequencer/test/settlement/Settlement.ts
@@ -313,7 +313,15 @@ export const settlementTestFn = (
   let acc0L2Nonce = 0;
 
   it("should throw error", async () => {
-    await expect(settlementModule.checkDeployment()).rejects.toThrow();
+    
+    const deploymentPromise = tokenConfig === undefined
+      ? settlementModule.checkDeployment()
+      : settlementModule.checkDeployment([{
+          address: tokenBridgeKey.toPublicKey(),
+          tokenId: tokenOwner!.deriveTokenId()
+        }]);
+  
+    await expect(deploymentPromise).rejects.toThrow();
   });
 
   it(
@@ -335,11 +343,6 @@ export const settlementTestFn = (
     },
     timeout * 2
   );
-
-  it("should not throw error", async () => {
-    // If it doesn't throw anything, it indicates that deployment checs were succesful. 
-    await settlementModule.checkDeployment();
-  });
 
   if (tokenConfig !== undefined) {
     it(
@@ -587,6 +590,12 @@ export const settlementTestFn = (
           .proveAndSendTransaction(tx, "included");
 
         const actions = await Mina.fetchActions(dispatch.address);
+        if (baseLayerConfig.network.type !== "local") {
+        await fetchAccount({
+          publicKey: tokenBridgeKey.toPublicKey(),
+          tokenId: bridgedTokenId
+        });
+       }
         const balanceDiff = bridge.account.balance
           .get()
           .sub(contractBalanceBefore);
@@ -789,4 +798,20 @@ export const settlementTestFn = (
     },
     timeout
   );
+
+  it("should not throw error after settlement", async () => {
+    // If it doesn't throw anything, it indicates that deployment checs were succesful. 
+    if(tokenConfig === undefined)
+    {
+    await settlementModule.checkDeployment();  
+    }
+    else{
+    await settlementModule.checkDeployment([
+        {
+          address: tokenBridgeKey.toPublicKey(),
+          tokenId: tokenOwner!.deriveTokenId()
+        }
+      ]);
+    }
+  });
 };

--- a/packages/sequencer/test/settlement/Settlement.ts
+++ b/packages/sequencer/test/settlement/Settlement.ts
@@ -704,7 +704,7 @@ export const settlementTestFn = (
 
       expect(settlementResult.bridgeTransactions).toHaveLength(2);
 
-      settlementModule.utils.fetchContractAccounts({
+      await settlementModule.utils.fetchContractAccounts({
           address: userKey.toPublicKey(),
           tokenId: bridgingContract.deriveTokenId(),
         });


### PR DESCRIPTION
### Purpose

We needed a way to check if the keys in the settlement module configuration are indeed private keys of contracts deployed on L1. To make it, a small function is implemented, which checks the deployment via  network configuration in `MinaBaseLayer`

This PR closes #352

### Commit Descriptions

- Added token contract addresses getter: b4e2780fd5226e6be4374b4e1717a6fbf5119f62. If there are no keys, an empty array is returned.
- Deployment check function is added 0ffc741d228005ca5a1db1a30422b188817a2ca3. It is configured to check both: 
   - Checking account in the local with `hasAccount` method 
   - Checking account with `fetchAccounts` method by using network configurations given in the `Settlement.test.ts`
   
- Added test cases to check the deployment before and after deployment d9da9bd25c2c3e6ec623c251caefe59a888a885e

