### PR TITLE
Display finality status of transaction

### DIFF
--- a/packages/explorer/src/app/blocks/[hash]/page.tsx
+++ b/packages/explorer/src/app/blocks/[hash]/page.tsx
@@ -18,7 +18,9 @@ export interface GetBlockQueryResponse {
       | {
           hash: string;
           height: string;
-          fromStateRoot: string;
+          result: {
+            stateRoot: string;
+          };
           transactions: {
             tx: {
               hash: string;
@@ -64,7 +66,9 @@ export default function BlockDetail() {
               block (where: {hash: "${params.hash}"}) {
                 height
                 hash
-                fromStateRoot
+                result {
+                  stateRoot
+                }
                 transactions {
                   tx {
                     hash,
@@ -109,7 +113,7 @@ export default function BlockDetail() {
     },
     {
       label: "StateRoot",
-      value: data?.block?.fromStateRoot ?? "—",
+      value: data?.block?.result.stateRoot ?? "—",
     },
   ];
 

--- a/packages/explorer/src/app/transactions/[hash]/page.tsx
+++ b/packages/explorer/src/app/transactions/[hash]/page.tsx
@@ -7,23 +7,27 @@ import Truncate from "react-truncate-inside/es";
 
 import { DetailsLayout } from "@/components/details/layout";
 import config from "@/config";
-
+interface Transaction {
+  hash: string;
+  sender: string;
+  methodId: string;
+  nonce: string;
+  executionResult: {
+    status: boolean;
+    statusMessage?: string;
+    block: {
+      batch: {
+        proof: string | null;
+        settlementTransactionHash: string | null;
+      };
+    };
+  };
+  status: boolean;
+  statusMessage?: string;
+}
 export interface GetTransactionQueryResponse {
   data: {
-    transaction:
-      | {
-          hash: string;
-          sender: string;
-          methodId: string;
-          nonce: string;
-          executionResult: {
-            status: boolean;
-            statusMessage?: string;
-          };
-          status: boolean;
-          statusMessage?: string;
-        }
-      | undefined;
+    transaction: Transaction | undefined;
   };
 }
 
@@ -49,6 +53,12 @@ export default function BlockDetail() {
                 executionResult {
                   status
                   statusMessage
+                  block {
+                    batch {
+                      proof
+                      settlementTransactionHash
+                    }
+                  }
                 }
             }
         }`,
@@ -71,13 +81,31 @@ export default function BlockDetail() {
     void query();
   }, []);
 
+  const getStatus = (tx: Transaction | undefined) => {
+    const batch = tx?.executionResult?.block?.batch;
+
+    if (!tx) return "Pending";
+    if (!batch) return tx?.executionResult?.block ? "Included" : "Pending";
+    if (batch.settlementTransactionHash) return "Settled";
+    if (batch.proof) return "Proven";
+
+    return "Included";
+  };
   const details = [
     {
       label: "Nonce",
       value: data?.transaction?.nonce ?? "—",
     },
     {
-      label: "Status",
+      label: "Finality status",
+      value: (
+        <div className="mt-1">
+          <span className="font-medium">{getStatus(data?.transaction)}</span>
+        </div>
+      ),
+    },
+    {
+      label: "Execution status",
       value: (
         <div className="mt-1">
           {data?.transaction?.executionResult?.status != null ? (

--- a/packages/explorer/src/app/transactions/[hash]/page.tsx
+++ b/packages/explorer/src/app/transactions/[hash]/page.tsx
@@ -7,6 +7,7 @@ import Truncate from "react-truncate-inside/es";
 
 import { DetailsLayout } from "@/components/details/layout";
 import config from "@/config";
+
 interface Transaction {
   hash: string;
   sender: string;
@@ -84,10 +85,11 @@ export default function BlockDetail() {
   const getStatus = (tx: Transaction | undefined) => {
     const batch = tx?.executionResult?.block?.batch;
 
-    if (!tx) return "Pending";
-    if (!batch) return tx?.executionResult?.block ? "Included" : "Pending";
-    if (batch.settlementTransactionHash) return "Settled";
-    if (batch.proof) return "Proven";
+    if (tx == null) return "Pending";
+    if (batch == null)
+      return tx?.executionResult?.block != null ? "Included" : "Pending";
+    if (batch.settlementTransactionHash != null) return "Settled";
+    if (batch.proof != null) return "Proven";
 
     return "Included";
   };

--- a/packages/explorer/src/components/blocks/BlocksPageClient.tsx
+++ b/packages/explorer/src/components/blocks/BlocksPageClient.tsx
@@ -23,7 +23,9 @@ export interface GetBlocksQueryResponse {
     blocks: {
       height: string;
       hash: string;
-      fromStateRoot: string;
+      result: {
+        stateRoot: string;
+      };
       _count: {
         transactions: number;
       };
@@ -131,7 +133,9 @@ export default function BlocksPageClient() {
           }){
             height
             hash
-            fromStateRoot
+            result {
+              stateRoot
+            }
             _count {
               transactions
             }
@@ -155,7 +159,7 @@ export default function BlocksPageClient() {
           height: item.height,
           hash: item.hash,
           transactions: item._count?.transactions?.toString(),
-          stateRoot: item.fromStateRoot,
+          stateRoot: item.result.stateRoot,
         })),
       });
       setLoading(false);

--- a/packages/explorer/src/components/pagination.tsx
+++ b/packages/explorer/src/components/pagination.tsx
@@ -22,8 +22,7 @@ export default function Pagination({ page, totalCount }: PaginationProps) {
   const nextPage = page + 1;
 
   const hasPreviousPage = page > 1;
-  const hasNextPage =
-    ((totalCount ?? 0) - page * showPerPage) / showPerPage > 1;
+  const hasNextPage = page * showPerPage < (totalCount ?? 0);
 
   const navigate = (to: number) => {
     const params = new URLSearchParams(window.location.search);

--- a/packages/indexer/src/IndexerNotifier.ts
+++ b/packages/indexer/src/IndexerNotifier.ts
@@ -6,14 +6,17 @@ import {
   TaskPayload,
   TaskQueue,
   SequencerIdProvider,
+  PrivateMempool,
 } from "@proto-kit/sequencer";
 import { log } from "@proto-kit/common";
 import { inject } from "tsyringe";
 
 import { IndexBlockTask } from "./tasks/IndexBlockTask";
+import { IndexPendingTxTask } from "./tasks/IndexPendingTxTask";
 
 export type NotifierMandatorySequencerModules = {
   BlockTrigger: typeof BlockTriggerBase;
+  Mempool: typeof PrivateMempool;
 };
 
 @sequencerModule()
@@ -24,6 +27,7 @@ export class IndexerNotifier extends SequencerModule<Record<never, never>> {
     @inject("TaskQueue")
     public taskQueue: TaskQueue,
     public indexBlockTask: IndexBlockTask,
+    public indexPendingTxTask: IndexPendingTxTask,
     private readonly sequencerIdProvider: SequencerIdProvider
   ) {
     super();
@@ -49,6 +53,27 @@ export class IndexerNotifier extends SequencerModule<Record<never, never>> {
       };
 
       await queue.addTask(task);
+    });
+    this.sequencer.events.on("mempool-transaction-added", async (tx) => {
+      try {
+        const txQueue = await this.taskQueue.getQueue(
+          this.indexPendingTxTask.name
+        );
+        const inputSerializer = this.indexPendingTxTask.inputSerializer();
+        const payload = await inputSerializer.toJSON(tx);
+        const sequencerId = this.sequencerIdProvider.getSequencerId();
+
+        const task: TaskPayload = {
+          name: this.indexPendingTxTask.name,
+          payload,
+          flowId: "",
+          sequencerId,
+        };
+
+        await txQueue.addTask(task);
+      } catch (err) {
+        console.error("Failed to add pending-tx task", err);
+      }
     });
   }
 

--- a/packages/indexer/src/IndexerNotifier.ts
+++ b/packages/indexer/src/IndexerNotifier.ts
@@ -36,6 +36,7 @@ export class IndexerNotifier extends SequencerModule<Record<never, never>> {
   public async propagateEventsAsTasks() {
     const queue = await this.taskQueue.getQueue(this.indexBlockTask.name);
     const inputSerializer = this.indexBlockTask.inputSerializer();
+    const txInputSerializer = this.indexPendingTxTask.inputSerializer();
 
     this.sequencer.events.on("block-metadata-produced", async (block) => {
       log.debug(
@@ -59,8 +60,7 @@ export class IndexerNotifier extends SequencerModule<Record<never, never>> {
         const txQueue = await this.taskQueue.getQueue(
           this.indexPendingTxTask.name
         );
-        const inputSerializer = this.indexPendingTxTask.inputSerializer();
-        const payload = await inputSerializer.toJSON(tx);
+        const payload = await txInputSerializer.toJSON(tx);
         const sequencerId = this.sequencerIdProvider.getSequencerId();
 
         const task: TaskPayload = {

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -4,3 +4,4 @@ export * from "./IndexerNotifier";
 export * from "./api/GeneratedResolverFactoryGraphqlModule";
 export * from "./tasks/IndexBlockTask";
 export * from "./tasks/IndexBlockTaskParameters";
+export * from "./tasks/IndexPendingTxTask";

--- a/packages/indexer/src/tasks/IndexPendingTxTask.ts
+++ b/packages/indexer/src/tasks/IndexPendingTxTask.ts
@@ -5,8 +5,9 @@ import {
   TaskWorkerModule,
   TransactionStorage,
 } from "@proto-kit/sequencer";
-import { inject, injectable } from "tsyringe";
 import { log } from "@proto-kit/common";
+import { inject, injectable } from "tsyringe";
+
 import { IndexPendingTxTaskParametersSerializer } from "./IndexPendingTxTaskParameters";
 
 @injectable()
@@ -32,7 +33,7 @@ export class IndexPendingTxTask
       await this.transactionStorage.pushUserTransaction(input);
       return "";
     } catch (err) {
-      log.error("Failed to process pending tx task", err as any);
+      log.error("Failed to process pending tx task", err);
       return undefined;
     }
   }

--- a/packages/indexer/src/tasks/IndexPendingTxTask.ts
+++ b/packages/indexer/src/tasks/IndexPendingTxTask.ts
@@ -1,0 +1,50 @@
+import {
+  PendingTransaction,
+  Task,
+  TaskSerializer,
+  TaskWorkerModule,
+  TransactionStorage,
+} from "@proto-kit/sequencer";
+import { inject, injectable } from "tsyringe";
+import { log } from "@proto-kit/common";
+import { IndexPendingTxTaskParametersSerializer } from "./IndexPendingTxTaskParameters";
+
+@injectable()
+export class IndexPendingTxTask
+  extends TaskWorkerModule
+  implements Task<PendingTransaction, string | void>
+{
+  public name = "index-pending-tx";
+
+  public constructor(
+    public taskSerializer: IndexPendingTxTaskParametersSerializer,
+    @inject("TransactionStorage")
+    public transactionStorage: TransactionStorage
+  ) {
+    super();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public async prepare(): Promise<void> {}
+
+  public async compute(input: PendingTransaction): Promise<string | void> {
+    try {
+      await this.transactionStorage.pushUserTransaction(input);
+      return "";
+    } catch (err) {
+      log.error("Failed to process pending tx task", err as any);
+      return undefined;
+    }
+  }
+
+  public inputSerializer(): TaskSerializer<PendingTransaction> {
+    return this.taskSerializer;
+  }
+
+  public resultSerializer(): TaskSerializer<string | void> {
+    return {
+      fromJSON: async () => {},
+      toJSON: async () => "",
+    };
+  }
+}

--- a/packages/indexer/src/tasks/IndexPendingTxTaskParameters.ts
+++ b/packages/indexer/src/tasks/IndexPendingTxTaskParameters.ts
@@ -1,0 +1,18 @@
+import { PendingTransaction } from "@proto-kit/sequencer";
+import { TransactionMapper } from "@proto-kit/persistance";
+import { injectable } from "tsyringe";
+
+@injectable()
+export class IndexPendingTxTaskParametersSerializer {
+  public constructor(public transactionMapper: TransactionMapper) {}
+
+  public toJSON(parameters: PendingTransaction): string {
+    return JSON.stringify(this.transactionMapper.mapOut(parameters));
+  }
+
+  public fromJSON(json: string): PendingTransaction {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const parsed = JSON.parse(json) as ReturnType<TransactionMapper["mapOut"]>;
+    return this.transactionMapper.mapIn(parsed);
+  }
+}

--- a/packages/indexer/src/tasks/IndexPendingTxTaskParameters.ts
+++ b/packages/indexer/src/tasks/IndexPendingTxTaskParameters.ts
@@ -7,12 +7,16 @@ export class IndexPendingTxTaskParametersSerializer {
   public constructor(public transactionMapper: TransactionMapper) {}
 
   public toJSON(parameters: PendingTransaction): string {
-    return JSON.stringify(this.transactionMapper.mapOut(parameters));
+    return JSON.stringify({
+      tx: this.transactionMapper.mapOut(parameters),
+    });
   }
 
   public fromJSON(json: string): PendingTransaction {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const parsed = JSON.parse(json) as ReturnType<TransactionMapper["mapOut"]>;
-    return this.transactionMapper.mapIn(parsed);
+    const parsed = JSON.parse(json) as {
+      tx: ReturnType<TransactionMapper["mapOut"]>;
+    };
+    return this.transactionMapper.mapIn(parsed.tx);
   }
 }

--- a/packages/persistance/src/services/prisma/PrismaBlockStorage.ts
+++ b/packages/persistance/src/services/prisma/PrismaBlockStorage.ts
@@ -106,7 +106,7 @@ export class PrismaBlockStorage implements BlockQueue, BlockStorage {
     //   ),
     //   skipDuplicates: true,
     // });
-    
+
     await prismaClient.block.create({
       data: {
         ...encodedBlock,

--- a/packages/persistance/src/services/prisma/PrismaBlockStorage.ts
+++ b/packages/persistance/src/services/prisma/PrismaBlockStorage.ts
@@ -97,12 +97,16 @@ export class PrismaBlockStorage implements BlockQueue, BlockStorage {
 
     const { prismaClient } = this.connection;
 
-    await prismaClient.transaction.createMany({
-      data: block.transactions.map((txr) =>
-        this.transactionMapper.mapOut(txr.tx)
-      ),
-      skipDuplicates: true,
-    });
+    // Note: We can assume all transactions are already in the DB here, because the
+    // mempool shares the same table as this one. But that could change in the future,
+    // then transaction have to be inserted-if-missing
+    // await prismaClient.transaction.createMany({
+    //   data: block.transactions.map((txr) =>
+    //     this.transactionMapper.mapOut(txr.tx)
+    //   ),
+    //   skipDuplicates: true,
+    // });
+    
     await prismaClient.block.create({
       data: {
         ...encodedBlock,


### PR DESCRIPTION
This PR closes #367 .

**Changes**

- Added a listener for mempool transactions and persisted them in the indexer database: [5445eb9](https://github.com/proto-kit/framework/commit/5445eb91944f21efda7ad8b04e51e1e2aa1d7d27)

- Implemented status resolution based on indexer data.

- Pending: transaction exists, executionResult is NULL.

- Included: transaction has an executionResult linked to a block.

- Proven: block is linked to a batch containing a proof.

- Settled: batch has a settlementTransactionHash.

- Finalized: omitted for now.

- Fixed pagination logic: [00bdcbe](https://github.com/proto-kit/framework/commit/00bdcbe67f3fe61064871034f180997ac298e3ff)

- Updated block views to use stateRoot from block results instead of fromStateRoot: [6fd2c81](https://github.com/proto-kit/framework/commit/6fd2c817e6cb6c1d1ee1c1d432aa580179cd30f0)