### PR TITLE
Refactor/make query a service

### DIFF
--- a/packages/sdk/src/client/ClientAppChain.ts
+++ b/packages/sdk/src/client/ClientAppChain.ts
@@ -19,18 +19,12 @@ import {
 } from "@proto-kit/protocol";
 import {
   DummyStateService,
-  NetworkStateQuery,
-  NetworkStateTransportModule,
   Query,
-  QueryBuilderFactory,
-  QueryTransportModule,
   Sequencer,
   UnsignedTransaction,
   AppChain,
   AppChainModule,
   MinimalAppChainDefinition,
-  BlockExplorerQuery,
-  BlockExplorerTransportModule,
 } from "@proto-kit/sequencer";
 import { container } from "tsyringe";
 import { Field, PublicKey, UInt64 } from "o1js";
@@ -42,6 +36,7 @@ import { GraphqlTransactionSender } from "../graphql/GraphqlTransactionSender";
 import { Signer } from "../transaction/InMemorySigner";
 import { AppChainTransaction } from "../transaction/AppChainTransaction";
 import { TransactionSender } from "../transaction/InMemoryTransactionSender";
+import { QueryService } from "../query/QueryService";
 
 export type InferModules<Container extends TypedClass<ModuleContainer<any>>> =
   Container extends TypedClass<infer Type>
@@ -53,6 +48,12 @@ export type InferModules<Container extends TypedClass<ModuleContainer<any>>> =
 export class ClientAppChain<
   AppChainModules extends MinimalAppChainDefinition,
 > extends AppChain<AppChainModules> {
+  // Optional for our lazy initialization purpose. 
+  private QueryService?: QueryService<
+    InferModules<AppChainModules["Runtime"]>,
+    InferModules<AppChainModules["Protocol"]>
+  >;
+
   public static from<Modules extends MinimalAppChainDefinition>(
     definition: Modules
   ) {
@@ -192,49 +193,17 @@ export class ClientAppChain<
     return transaction;
   }
 
-  public get query(): {
-    runtime: Query<
-      RuntimeModule<unknown>,
-      InferModules<AppChainModules["Runtime"]>
-    >;
-    protocol: Query<
-      ProtocolModule<unknown>,
-      InferModules<AppChainModules["Protocol"]>
-    >;
-    network: NetworkStateQuery;
-    explorer: BlockExplorerQuery;
-  } {
-    const queryTransportModule = this.container.resolve<QueryTransportModule>(
-      "QueryTransportModule"
-    );
-
-    const networkStateTransportModule =
-      this.container.resolve<NetworkStateTransportModule>(
-        "NetworkStateTransportModule"
-      );
-
-    const blockExplorerTransportModule =
-      this.container.resolve<BlockExplorerTransportModule>(
-        "BlockExplorerTransportModule"
-      );
-
-    const network = new NetworkStateQuery(networkStateTransportModule);
-    const explorer = new BlockExplorerQuery(blockExplorerTransportModule);
-
-    return {
-      runtime: QueryBuilderFactory.fromRuntime(
+  public get query(): QueryService<
+    InferModules<AppChainModules["Runtime"]>,
+    InferModules<AppChainModules["Protocol"]>
+  > {
+    if (this.QueryService === undefined) {
+      this.QueryService = new QueryService(
         this.runtime,
-        queryTransportModule
-      ),
-
-      protocol: QueryBuilderFactory.fromProtocol(
         this.protocol,
-        queryTransportModule
-      ),
-
-      network,
-
-      explorer,
-    };
+        this.container
+      );
+    }
+    return this.QueryService;
   }
 }

--- a/packages/sdk/src/client/ClientAppChain.ts
+++ b/packages/sdk/src/client/ClientAppChain.ts
@@ -49,7 +49,7 @@ export class ClientAppChain<
   AppChainModules extends MinimalAppChainDefinition,
 > extends AppChain<AppChainModules> {
   // Optional for our lazy initialization purpose.
-  private QueryService?: QueryService<
+  private queryService?: QueryService<
     InferModules<AppChainModules["Runtime"]>,
     InferModules<AppChainModules["Protocol"]>
   >;
@@ -197,13 +197,13 @@ export class ClientAppChain<
     InferModules<AppChainModules["Runtime"]>,
     InferModules<AppChainModules["Protocol"]>
   > {
-    if (this.QueryService === undefined) {
-      this.QueryService = new QueryService(
+    if (this.queryService === undefined) {
+      this.queryService = new QueryService(
         this.runtime,
         this.protocol,
         this.container
       );
     }
-    return this.QueryService;
+    return this.queryService;
   }
 }

--- a/packages/sdk/src/client/ClientAppChain.ts
+++ b/packages/sdk/src/client/ClientAppChain.ts
@@ -48,12 +48,6 @@ export type InferModules<Container extends TypedClass<ModuleContainer<any>>> =
 export class ClientAppChain<
   AppChainModules extends MinimalAppChainDefinition,
 > extends AppChain<AppChainModules> {
-  // Optional for our lazy initialization purpose.
-  private queryService?: QueryService<
-    InferModules<AppChainModules["Runtime"]>,
-    InferModules<AppChainModules["Protocol"]>
-  >;
-
   public static from<Modules extends MinimalAppChainDefinition>(
     definition: Modules
   ) {
@@ -197,13 +191,11 @@ export class ClientAppChain<
     InferModules<AppChainModules["Runtime"]>,
     InferModules<AppChainModules["Protocol"]>
   > {
-    if (this.queryService === undefined) {
-      this.queryService = new QueryService(
-        this.runtime,
-        this.protocol,
-        this.container
-      );
-    }
-    return this.queryService;
+    return this.container.resolve<
+      QueryService<
+        InferModules<AppChainModules["Runtime"]>,
+        InferModules<AppChainModules["Protocol"]>
+      >
+    >(QueryService);
   }
 }

--- a/packages/sdk/src/client/ClientAppChain.ts
+++ b/packages/sdk/src/client/ClientAppChain.ts
@@ -48,7 +48,7 @@ export type InferModules<Container extends TypedClass<ModuleContainer<any>>> =
 export class ClientAppChain<
   AppChainModules extends MinimalAppChainDefinition,
 > extends AppChain<AppChainModules> {
-  // Optional for our lazy initialization purpose. 
+  // Optional for our lazy initialization purpose.
   private QueryService?: QueryService<
     InferModules<AppChainModules["Runtime"]>,
     InferModules<AppChainModules["Protocol"]>

--- a/packages/sdk/src/query/QueryService.ts
+++ b/packages/sdk/src/query/QueryService.ts
@@ -25,8 +25,7 @@ import {
 export class QueryService<
   RuntimeModules extends RuntimeModulesRecord,
   ProtocolModules extends ProtocolModulesRecord &
-    MandatoryProtocolModulesRecord = ProtocolModulesRecord &
-    MandatoryProtocolModulesRecord,
+    MandatoryProtocolModulesRecord
 > {
   // Lazily initialized query instances
   private RuntimeQuery?: Query<RuntimeModule<unknown>, RuntimeModules>;

--- a/packages/sdk/src/query/QueryService.ts
+++ b/packages/sdk/src/query/QueryService.ts
@@ -1,0 +1,96 @@
+import { DependencyContainer } from "tsyringe";
+import { Runtime, RuntimeModule, RuntimeModulesRecord } from "@proto-kit/module";
+import {
+  MandatoryProtocolModulesRecord,
+  Protocol,
+  ProtocolModule,
+  ProtocolModulesRecord,
+} from "@proto-kit/protocol";
+import {
+  BlockExplorerQuery,
+  BlockExplorerTransportModule,
+  NetworkStateQuery,
+  NetworkStateTransportModule,
+  Query,
+  QueryTransportModule,
+} from "@proto-kit/sequencer";
+
+export class QueryService<
+  RuntimeModules extends RuntimeModulesRecord,
+  ProtocolModules extends ProtocolModulesRecord &
+    MandatoryProtocolModulesRecord = ProtocolModulesRecord &
+    MandatoryProtocolModulesRecord,
+> {
+  
+  // Here, fields are optional for lazy initialization. 
+  private QueryTransport?: QueryTransportModule;
+  private NetworkStateTransport?: NetworkStateTransportModule;
+  private BlockExplorerTransport?: BlockExplorerTransportModule;
+
+
+  private RuntimeQuery?: Query<RuntimeModule<unknown>, RuntimeModules>;
+  private ProtocolQuery?: Query<ProtocolModule<unknown>, ProtocolModules>;
+  private NetworkQuery?: NetworkStateQuery;
+  private ExplorerQuery?: BlockExplorerQuery;
+
+  public constructor(
+    private readonly runtimeInstance: Runtime<RuntimeModules>,
+    private readonly protocolInstance: Protocol<ProtocolModules>,
+    private readonly container: DependencyContainer
+  ) {}
+
+
+  /**
+   * A helper function that resolves QueryTrasnportModule.
+   * If not resolved before, it is resolved.  
+   * @returns The registered transport module as {@link QueryTrasnportModule}
+   */
+  private get queryTransport(): QueryTransportModule {
+    if (this.QueryTransport === undefined) {
+      if (!this.container.isRegistered("QueryTransportModule")) {
+        throw new Error(
+          "QueryTransportModule is not registered");
+      }
+      this.QueryTransport =
+        this.container.resolve<QueryTransportModule>("QueryTransportModule");
+    }
+    return this.QueryTransport;
+  }
+
+  /**
+   * A helper function that resolves NetworkStateTransport.
+   * If not resolved before, it is resolved.  
+   * @returns The registered transport module as {@link BlockExplorerTransport}
+   */
+  private get networkStateTransport(): NetworkStateTransportModule {
+    if (this.NetworkStateTransport === undefined) {
+      if (!this.container.isRegistered("NetworkStateTransportModule")) {
+        throw new Error("NetworkStateTransportModule is not registered.");
+      }
+      this.NetworkStateTransport =
+        this.container.resolve<NetworkStateTransportModule>(
+          "NetworkStateTransportModule"
+        );
+    }
+    return this.NetworkStateTransport;
+  }
+
+  /**
+   * A helper function that resolves BlockExplorerTransportModule.
+   * If not resolved before, it is resolved.  
+   * @returns The registered transport module as {@link BlockExplorerTransport}
+   */
+  private get blockExplorerTransport(): BlockExplorerTransportModule {
+    if (this.BlockExplorerTransport === undefined) {
+      if (!this.container.isRegistered("BlockExplorerTransportModule")) {
+        throw new Error(
+          "BlockExplorerTransportModule is not registered.");
+      }
+      this.BlockExplorerTransport =
+        this.container.resolve<BlockExplorerTransportModule>(
+          "BlockExplorerTransportModule"
+        );
+    }
+    return this.BlockExplorerTransport;
+  }
+}

--- a/packages/sdk/src/query/QueryService.ts
+++ b/packages/sdk/src/query/QueryService.ts
@@ -1,4 +1,4 @@
-import { DependencyContainer } from "tsyringe";
+import { inject, injectable, Lifecycle, scoped } from "tsyringe";
 import {
   Runtime,
   RuntimeModule,
@@ -20,19 +20,15 @@ import {
   QueryTransportModule,
 } from "@proto-kit/sequencer";
 
+@scoped(Lifecycle.ContainerScoped)
+@injectable()
 export class QueryService<
   RuntimeModules extends RuntimeModulesRecord,
   ProtocolModules extends ProtocolModulesRecord &
     MandatoryProtocolModulesRecord = ProtocolModulesRecord &
     MandatoryProtocolModulesRecord,
 > {
-  // Here, fields are optional for lazy initialization.
-  private QueryTransport?: QueryTransportModule;
-
-  private NetworkStateTransport?: NetworkStateTransportModule;
-
-  private BlockExplorerTransport?: BlockExplorerTransportModule;
-
+  // Lazily initialized query instances
   private RuntimeQuery?: Query<RuntimeModule<unknown>, RuntimeModules>;
 
   private ProtocolQuery?: Query<ProtocolModule<unknown>, ProtocolModules>;
@@ -42,54 +38,17 @@ export class QueryService<
   private ExplorerQuery?: BlockExplorerQuery;
 
   public constructor(
+    @inject("Runtime")
     private readonly runtimeInstance: Runtime<RuntimeModules>,
+    @inject("Protocol")
     private readonly protocolInstance: Protocol<ProtocolModules>,
-    private readonly container: DependencyContainer
+    @inject("QueryTransportModule", { isOptional: true })
+    private readonly queryTransport: QueryTransportModule,
+    @inject("NetworkStateTransportModule", { isOptional: true })
+    private readonly networkStateTransport: NetworkStateTransportModule,
+    @inject("BlockExplorerTransportModule", { isOptional: true })
+    private readonly blockExplorerTransport: BlockExplorerTransportModule
   ) {}
-
-  /**
-   * A helper function that resolves QueryTrasnportModule.
-   * If not resolved before, it is resolved.
-   * @returns The registered transport module as {@link QueryTrasnportModule}
-   */
-  private get queryTransport(): QueryTransportModule {
-    if (this.QueryTransport === undefined) {
-      this.QueryTransport = this.container.resolve<QueryTransportModule>(
-        "QueryTransportModule"
-      );
-    }
-    return this.QueryTransport;
-  }
-
-  /**
-   * A helper function that resolves NetworkStateTransport.
-   * If not resolved before, it is resolved.
-   * @returns The registered transport module as {@link BlockExplorerTransport}
-   */
-  private get networkStateTransport(): NetworkStateTransportModule {
-    if (this.NetworkStateTransport === undefined) {
-      this.NetworkStateTransport =
-        this.container.resolve<NetworkStateTransportModule>(
-          "NetworkStateTransportModule"
-        );
-    }
-    return this.NetworkStateTransport;
-  }
-
-  /**
-   * A helper function that resolves BlockExplorerTransportModule.
-   * If not resolved before, it is resolved.
-   * @returns The registered transport module as {@link BlockExplorerTransport}
-   */
-  private get blockExplorerTransport(): BlockExplorerTransportModule {
-    if (this.BlockExplorerTransport === undefined) {
-      this.BlockExplorerTransport =
-        this.container.resolve<BlockExplorerTransportModule>(
-          "BlockExplorerTransportModule"
-        );
-    }
-    return this.BlockExplorerTransport;
-  }
 
   /**
    * Getter of query module for runtime modules.

--- a/packages/sdk/src/query/QueryService.ts
+++ b/packages/sdk/src/query/QueryService.ts
@@ -25,7 +25,7 @@ import {
 export class QueryService<
   RuntimeModules extends RuntimeModulesRecord,
   ProtocolModules extends ProtocolModulesRecord &
-    MandatoryProtocolModulesRecord
+    MandatoryProtocolModulesRecord,
 > {
   // Lazily initialized query instances
   private RuntimeQuery?: Query<RuntimeModule<unknown>, RuntimeModules>;

--- a/packages/sdk/src/query/QueryService.ts
+++ b/packages/sdk/src/query/QueryService.ts
@@ -54,9 +54,6 @@ export class QueryService<
    */
   private get queryTransport(): QueryTransportModule {
     if (this.QueryTransport === undefined) {
-      if (!this.container.isRegistered("QueryTransportModule")) {
-        throw new Error("QueryTransportModule is not registered");
-      }
       this.QueryTransport = this.container.resolve<QueryTransportModule>(
         "QueryTransportModule"
       );
@@ -71,9 +68,6 @@ export class QueryService<
    */
   private get networkStateTransport(): NetworkStateTransportModule {
     if (this.NetworkStateTransport === undefined) {
-      if (!this.container.isRegistered("NetworkStateTransportModule")) {
-        throw new Error("NetworkStateTransportModule is not registered.");
-      }
       this.NetworkStateTransport =
         this.container.resolve<NetworkStateTransportModule>(
           "NetworkStateTransportModule"
@@ -89,9 +83,6 @@ export class QueryService<
    */
   private get blockExplorerTransport(): BlockExplorerTransportModule {
     if (this.BlockExplorerTransport === undefined) {
-      if (!this.container.isRegistered("BlockExplorerTransportModule")) {
-        throw new Error("BlockExplorerTransportModule is not registered.");
-      }
       this.BlockExplorerTransport =
         this.container.resolve<BlockExplorerTransportModule>(
           "BlockExplorerTransportModule"

--- a/packages/sdk/src/query/QueryService.ts
+++ b/packages/sdk/src/query/QueryService.ts
@@ -1,5 +1,9 @@
 import { DependencyContainer } from "tsyringe";
-import { Runtime, RuntimeModule, RuntimeModulesRecord } from "@proto-kit/module";
+import {
+  Runtime,
+  RuntimeModule,
+  RuntimeModulesRecord,
+} from "@proto-kit/module";
 import {
   MandatoryProtocolModulesRecord,
   Protocol,
@@ -22,16 +26,19 @@ export class QueryService<
     MandatoryProtocolModulesRecord = ProtocolModulesRecord &
     MandatoryProtocolModulesRecord,
 > {
-  
-  // Here, fields are optional for lazy initialization. 
+  // Here, fields are optional for lazy initialization.
   private QueryTransport?: QueryTransportModule;
+
   private NetworkStateTransport?: NetworkStateTransportModule;
+
   private BlockExplorerTransport?: BlockExplorerTransportModule;
 
-
   private RuntimeQuery?: Query<RuntimeModule<unknown>, RuntimeModules>;
+
   private ProtocolQuery?: Query<ProtocolModule<unknown>, ProtocolModules>;
+
   private NetworkQuery?: NetworkStateQuery;
+
   private ExplorerQuery?: BlockExplorerQuery;
 
   public constructor(
@@ -40,27 +47,26 @@ export class QueryService<
     private readonly container: DependencyContainer
   ) {}
 
-
   /**
    * A helper function that resolves QueryTrasnportModule.
-   * If not resolved before, it is resolved.  
+   * If not resolved before, it is resolved.
    * @returns The registered transport module as {@link QueryTrasnportModule}
    */
   private get queryTransport(): QueryTransportModule {
     if (this.QueryTransport === undefined) {
       if (!this.container.isRegistered("QueryTransportModule")) {
-        throw new Error(
-          "QueryTransportModule is not registered");
+        throw new Error("QueryTransportModule is not registered");
       }
-      this.QueryTransport =
-        this.container.resolve<QueryTransportModule>("QueryTransportModule");
+      this.QueryTransport = this.container.resolve<QueryTransportModule>(
+        "QueryTransportModule"
+      );
     }
     return this.QueryTransport;
   }
 
   /**
    * A helper function that resolves NetworkStateTransport.
-   * If not resolved before, it is resolved.  
+   * If not resolved before, it is resolved.
    * @returns The registered transport module as {@link BlockExplorerTransport}
    */
   private get networkStateTransport(): NetworkStateTransportModule {
@@ -78,14 +84,13 @@ export class QueryService<
 
   /**
    * A helper function that resolves BlockExplorerTransportModule.
-   * If not resolved before, it is resolved.  
+   * If not resolved before, it is resolved.
    * @returns The registered transport module as {@link BlockExplorerTransport}
    */
   private get blockExplorerTransport(): BlockExplorerTransportModule {
     if (this.BlockExplorerTransport === undefined) {
       if (!this.container.isRegistered("BlockExplorerTransportModule")) {
-        throw new Error(
-          "BlockExplorerTransportModule is not registered.");
+        throw new Error("BlockExplorerTransportModule is not registered.");
       }
       this.BlockExplorerTransport =
         this.container.resolve<BlockExplorerTransportModule>(
@@ -96,9 +101,9 @@ export class QueryService<
   }
 
   /**
-   * Getter of query module for runtime modules. 
-   * If not initialized before, it is initialized. 
-   * @returns A {@link Query} module for runtime module. 
+   * Getter of query module for runtime modules.
+   * If not initialized before, it is initialized.
+   * @returns A {@link Query} module for runtime module.
    */
   public get runtime(): Query<RuntimeModule<unknown>, RuntimeModules> {
     if (this.RuntimeQuery === undefined) {
@@ -111,9 +116,9 @@ export class QueryService<
   }
 
   /**
-   * Getter of query module for protocol. 
-   * If not initialized before, it is initialized. 
-   * @returns A {@link Query} module for protocol module. 
+   * Getter of query module for protocol.
+   * If not initialized before, it is initialized.
+   * @returns A {@link Query} module for protocol module.
    */
   public get protocol(): Query<ProtocolModule<unknown>, ProtocolModules> {
     if (this.ProtocolQuery === undefined) {
@@ -126,29 +131,25 @@ export class QueryService<
   }
 
   /**
-   * Getter of network state query module. 
-   * If not initialized before, it is initialized. 
-   * @returns A {@link NetworkStateQuery} module. 
+   * Getter of network state query module.
+   * If not initialized before, it is initialized.
+   * @returns A {@link NetworkStateQuery} module.
    */
   public get network(): NetworkStateQuery {
     if (this.NetworkQuery === undefined) {
-      this.NetworkQuery = new NetworkStateQuery(
-        this.networkStateTransport
-      );
+      this.NetworkQuery = new NetworkStateQuery(this.networkStateTransport);
     }
     return this.NetworkQuery;
   }
 
   /**
-   * Getter of block explorer query module. 
-   * If not initialized before, it is initialized. 
-   * @returns A {@link BlockExplorerQuery} module. 
+   * Getter of block explorer query module.
+   * If not initialized before, it is initialized.
+   * @returns A {@link BlockExplorerQuery} module.
    */
   public get explorer(): BlockExplorerQuery {
     if (this.ExplorerQuery === undefined) {
-      this.ExplorerQuery = new BlockExplorerQuery(
-        this.blockExplorerTransport
-      );
+      this.ExplorerQuery = new BlockExplorerQuery(this.blockExplorerTransport);
     }
     return this.ExplorerQuery;
   }

--- a/packages/sdk/src/query/QueryService.ts
+++ b/packages/sdk/src/query/QueryService.ts
@@ -12,6 +12,7 @@ import {
   NetworkStateQuery,
   NetworkStateTransportModule,
   Query,
+  QueryBuilderFactory,
   QueryTransportModule,
 } from "@proto-kit/sequencer";
 
@@ -92,5 +93,63 @@ export class QueryService<
         );
     }
     return this.BlockExplorerTransport;
+  }
+
+  /**
+   * Getter of query module for runtime modules. 
+   * If not initialized before, it is initialized. 
+   * @returns A {@link Query} module for runtime module. 
+   */
+  public get runtime(): Query<RuntimeModule<unknown>, RuntimeModules> {
+    if (this.RuntimeQuery === undefined) {
+      this.RuntimeQuery = QueryBuilderFactory.fromRuntime(
+        this.runtimeInstance,
+        this.queryTransport
+      );
+    }
+    return this.RuntimeQuery;
+  }
+
+  /**
+   * Getter of query module for protocol. 
+   * If not initialized before, it is initialized. 
+   * @returns A {@link Query} module for protocol module. 
+   */
+  public get protocol(): Query<ProtocolModule<unknown>, ProtocolModules> {
+    if (this.ProtocolQuery === undefined) {
+      this.ProtocolQuery = QueryBuilderFactory.fromProtocol(
+        this.protocolInstance,
+        this.queryTransport
+      );
+    }
+    return this.ProtocolQuery;
+  }
+
+  /**
+   * Getter of network state query module. 
+   * If not initialized before, it is initialized. 
+   * @returns A {@link NetworkStateQuery} module. 
+   */
+  public get network(): NetworkStateQuery {
+    if (this.NetworkQuery === undefined) {
+      this.NetworkQuery = new NetworkStateQuery(
+        this.networkStateTransport
+      );
+    }
+    return this.NetworkQuery;
+  }
+
+  /**
+   * Getter of block explorer query module. 
+   * If not initialized before, it is initialized. 
+   * @returns A {@link BlockExplorerQuery} module. 
+   */
+  public get explorer(): BlockExplorerQuery {
+    if (this.ExplorerQuery === undefined) {
+      this.ExplorerQuery = new BlockExplorerQuery(
+        this.blockExplorerTransport
+      );
+    }
+    return this.ExplorerQuery;
   }
 }


### PR DESCRIPTION
## Description 
This PR refactors query logic in `ClientAppChain` by extracting it into a dedicated `QueryService` class with lazy initialization patterns.

## Changes 
- Added `QueryService` class with lazy-initialized getters for runtime, protocol, network, and explorer query modules f00c371
- Implemented resolver functions for transport modules `QueryTransportModule`, `NetworkStateTransportModule`, `BlockExplorerTransportModule` f00c371
- Added lazy initialization pattern to `QueryService` for query modules 23b6d4b
- Updated `ClientAppChain` to use `QueryService` 880358f


This PR closes #349