### PR TITLE
Implemented CircuitAnalysisModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Added CircuitAnalysisModule for easy analysis of protocol circuits [#379](https://github.com/proto-kit/framework/pull/379)
 - Separated settlement and bridging functionally, so now settlement can be used without bridging [#376](https://github.com/proto-kit/framework/pull/376)
 - Added nightly releases via pkg.pr.new [#384](https://github.com/proto-kit/framework/pull/384)
 - Introduced Changelog [#378](https://github.com/proto-kit/framework/pull/378)

--- a/packages/common/src/log.ts
+++ b/packages/common/src/log.ts
@@ -28,6 +28,8 @@ function logProvable(
 // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 if (process.env?.IN_CI ?? false) {
   loglevel.setLevel("ERROR");
+} else {
+  loglevel.setLevel("INFO");
 }
 
 const timeMap: Record<string, number> = {};

--- a/packages/sequencer/src/helpers/CircuitAnalysisModule.ts
+++ b/packages/sequencer/src/helpers/CircuitAnalysisModule.ts
@@ -1,0 +1,75 @@
+import { inject, injectable } from "tsyringe";
+import { RuntimeEnvironment } from "@proto-kit/module";
+import { log, mapSequential, PlainZkProgram } from "@proto-kit/common";
+import {
+  MandatoryProtocolModulesRecord,
+  Protocol,
+  ProtocolModulesRecord,
+  SettlementContractModule,
+  SettlementModulesRecord,
+} from "@proto-kit/protocol";
+
+@injectable()
+export class CircuitAnalysisModule {
+  public constructor(
+    @inject("Protocol")
+    private readonly protocol: Protocol<
+      ProtocolModulesRecord & MandatoryProtocolModulesRecord
+    >,
+    @inject("Runtime")
+    private readonly runtime: RuntimeEnvironment
+  ) {}
+
+  public async printSummary() {
+    const summary = await this.analyseMethods();
+    log.info(summary);
+  }
+
+  public async analyseMethods() {
+    const zkProgrammables = [
+      this.runtime,
+      this.protocol.stateTransitionProver,
+      this.protocol.transactionProver,
+      this.protocol.blockProver,
+    ];
+
+    const zkProgrammablePromises = await mapSequential(
+      zkProgrammables,
+      (withZkProgrammable) =>
+        mapSequential(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          withZkProgrammable.zkProgrammable.zkProgramFactory() as PlainZkProgram<
+            unknown,
+            unknown
+          >[],
+          async (program) => {
+            const result = await program.analyzeMethods();
+            return [program.name, result] as const;
+          }
+        )
+    );
+
+    const settlementModule = this.protocol.dependencyContainer.resolve<
+      SettlementContractModule<SettlementModulesRecord>
+    >("SettlementContractModule");
+
+    const contractPromises = await mapSequential(
+      Object.entries(settlementModule.getContractClasses()),
+      async ([key, clas]) => {
+        const result = await clas.analyzeMethods();
+        return [key, result] as const;
+      }
+    );
+
+    const allResults = [...zkProgrammablePromises.flat(), ...contractPromises];
+
+    const summary = allResults.map(([program, result]) => {
+      const methods = Object.entries(result).map(
+        ([methodName, constraints]) => [methodName, constraints.rows] as const
+      );
+      return [program, Object.fromEntries(methods)] as const;
+    });
+
+    return Object.fromEntries(summary);
+  }
+}

--- a/packages/sequencer/src/index.ts
+++ b/packages/sequencer/src/index.ts
@@ -87,6 +87,7 @@ export * from "./helpers/query/NetworkStateQuery";
 export * from "./helpers/query/NetworkStateTransportModule";
 export * from "./helpers/query/BlockExplorerQuery";
 export * from "./helpers/query/BlockExplorerTransportModule";
+export * from "./helpers/CircuitAnalysisModule";
 export * from "./state/prefilled/PreFilledStateService";
 export * from "./state/async/AsyncMerkleTreeStore";
 export * from "./state/async/AsyncStateService";

--- a/packages/sequencer/test/settlement/Settlement.ts
+++ b/packages/sequencer/test/settlement/Settlement.ts
@@ -56,6 +56,7 @@ import {
   VanillaTaskWorkerModules,
   Sequencer,
   InMemoryMinaSigner,
+  CircuitAnalysisModule,
 } from "../../src";
 import { BlockProofSerializer } from "../../src/protocol/production/tasks/serializers/BlockProofSerializer";
 import { testingSequencerModules } from "../TestingSequencer";
@@ -312,6 +313,12 @@ export const settlementTestFn = (
   let nonceCounter = 0;
   let user0Nonce = 0;
   let acc0L2Nonce = 0;
+
+  it.only("Print constraint summary", async () => {
+    await appChain.protocol.dependencyContainer
+      .resolve(CircuitAnalysisModule)
+      .printSummary();
+  });
 
   it("should throw error", async () => {
     const additionalAddresses =

--- a/packages/sequencer/test/settlement/Settlement.ts
+++ b/packages/sequencer/test/settlement/Settlement.ts
@@ -314,7 +314,7 @@ export const settlementTestFn = (
   let user0Nonce = 0;
   let acc0L2Nonce = 0;
 
-  it.only("Print constraint summary", async () => {
+  it.skip("Print constraint summary", async () => {
     await appChain.protocol.dependencyContainer
       .resolve(CircuitAnalysisModule)
       .printSummary();


### PR DESCRIPTION
Based on #377 

Implemented a module that prints out a summary of all circuits created by a specific appchain instance. The summary currently includes row count (i.e. constraints).

Output for the settlement test:
```js
{
  'RuntimeProgram-0': {
    'Balances.deposit': 383,
    'Balances.mint': 382,
    'Balances.setBalance': 236,
    'Balances.transfer': 707,
    'Balances.transferSigned': 721,
    'Withdrawals.withdraw': 905
  },
  StateTransitionProver: { merge: 0, proveBatch: 10323 },
  BlockProver: { merge: 22, proveBlock: 1359 },
  SettlementContract: { approveBase: 6175, addTokenBridge: 1195, settle: 1345 },
  DispatchContract: { enableTokenDeposits: 8295, updateMessagesHash: 667, deposit: 6586 },
  BridgeContract: { updateStateRoot: 640, rollupOutgoingMessages: 1665, redeem: 1566 },
  // fungible token omitted
}
```

Todo:
- [ ] Add CLI command to print out the summary