### PR TITLE
Refactor/busy pattern

### DIFF
--- a/packages/sequencer/src/helpers/BusyGuard.ts
+++ b/packages/sequencer/src/helpers/BusyGuard.ts
@@ -3,35 +3,31 @@ import { log } from "@proto-kit/common";
  * Decorator that ensures a function/method is not currently in use.
  * Mostly useful for production of blocks, batches and tasks.
  */
-export function ensureNotBusy() {
-  return function InnerFunction(
-    target: object,
+export function ensureNotBusy<T>() {
+
+  let inProgress = false;
+
+  return function innerFunction(
+    _target: T,
     methodName: string,
     descriptor: TypedPropertyDescriptor<(...args: any[]) => Promise<any>>
-  ) {
+  ): void {
     const originalMethod = descriptor.value!;
 
-    // eslint-disable-next-line consistent-return
-    descriptor.value = async function value(
-      this: { inProgress: boolean },
-      ...args: any[]
+    descriptor.value = async function wrapped(
+      this: T,
+      ...args: unknown[]
     ) {
-      if (this.inProgress === true) {
-        log.info(`${methodName.toString()} is in use at the moment.`);
+      if (inProgress) {
+        log.trace(`${methodName} is in use at the moment.`);
         return undefined;
       }
 
-      this.inProgress = true;
+      inProgress = true;
       try {
         return await originalMethod.apply(this, args);
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          throw error;
-        } else {
-          log.error(error);
-        }
       } finally {
-        this.inProgress = false;
+        inProgress = false;
       }
     };
   };

--- a/packages/sequencer/src/helpers/BusyGuard.ts
+++ b/packages/sequencer/src/helpers/BusyGuard.ts
@@ -11,7 +11,8 @@ export function ensureNotBusy() {
   ) {
     const originalMethod = descriptor.value!;
 
-    descriptor.value = async function decorator(
+    // eslint-disable-next-line consistent-return
+    descriptor.value = async function value(
       this: { inProgress: boolean },
       ...args: any[]
     ) {

--- a/packages/sequencer/src/helpers/BusyGuard.ts
+++ b/packages/sequencer/src/helpers/BusyGuard.ts
@@ -1,0 +1,37 @@
+import { log } from "@proto-kit/common";
+/**
+ * Decorator that ensures a function/method is not currently in use.
+ * Mostly useful for production of blocks, batches and tasks.
+ */
+export function ensureNotBusy() {
+  return function InnerFunction(
+    target: object,
+    methodName: string,
+    descriptor: TypedPropertyDescriptor<(...args: any[]) => Promise<any>>
+  ) {
+    const originalMethod = descriptor.value!;
+
+    descriptor.value = async function decorator(
+      this: { inProgress: boolean },
+      ...args: any[]
+    ) {
+      if (this.inProgress === true) {
+        log.info(`${methodName.toString()} is in use at the moment.`);
+        return undefined;
+      }
+
+      this.inProgress = true;
+      try {
+        return await originalMethod.apply(this, args);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          throw error;
+        } else {
+          log.error(error);
+        }
+      } finally {
+        this.inProgress = false;
+      }
+    };
+  };
+}

--- a/packages/sequencer/src/helpers/BusyGuard.ts
+++ b/packages/sequencer/src/helpers/BusyGuard.ts
@@ -4,7 +4,6 @@ import { log } from "@proto-kit/common";
  * Mostly useful for production of blocks, batches and tasks.
  */
 export function ensureNotBusy<T>() {
-
   let inProgress = false;
 
   return function innerFunction(
@@ -14,10 +13,7 @@ export function ensureNotBusy<T>() {
   ): void {
     const originalMethod = descriptor.value!;
 
-    descriptor.value = async function wrapped(
-      this: T,
-      ...args: unknown[]
-    ) {
+    descriptor.value = async function wrapped(this: T, ...args: unknown[]) {
       if (inProgress) {
         log.trace(`${methodName} is in use at the moment.`);
         return undefined;

--- a/packages/sequencer/src/index.ts
+++ b/packages/sequencer/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./helpers/utils";
+export * from "./helpers/BusyGuard";
 export * from "./mempool/Mempool";
 export * from "./mempool/PendingTransaction";
 export * from "./mempool/CompressedSignature";

--- a/packages/sequencer/src/protocol/production/BatchProducerModule.ts
+++ b/packages/sequencer/src/protocol/production/BatchProducerModule.ts
@@ -63,13 +63,13 @@ export class BatchProducerModule extends SequencerModule {
    * transactions that are present in the mempool. This function should also
    * be the one called by BlockTriggerss
    */
-  @ensureNotBusy()
   public async createBatch(
     blocks: BlockWithResult[]
   ): Promise<SettleableBatch | undefined> {
     return await this.tryProduceBatch(blocks);
   }
-
+  
+  @ensureNotBusy()
   private async tryProduceBatch(
     blocks: BlockWithResult[]
   ): Promise<SettleableBatch | undefined> {

--- a/packages/sequencer/src/protocol/production/BatchProducerModule.ts
+++ b/packages/sequencer/src/protocol/production/BatchProducerModule.ts
@@ -17,6 +17,7 @@ import { BlockWithResult } from "../../storage/model/Block";
 import type { Database } from "../../storage/Database";
 import { AsyncLinkedLeafStore } from "../../state/async/AsyncLinkedLeafStore";
 import { CachedLinkedLeafStore } from "../../state/lmt/CachedLinkedLeafStore";
+import { ensureNotBusy } from "../../helpers/BusyGuard";
 
 import { BlockProofSerializer } from "./tasks/serializers/BlockProofSerializer";
 import { BatchTracingService } from "./tracing/BatchTracingService";
@@ -44,8 +45,6 @@ const errors = {
  */
 @sequencerModule()
 export class BatchProducerModule extends SequencerModule {
-  private productionInProgress = false;
-
   public constructor(
     @inject("AsyncLinkedLeafStore")
     private readonly merkleStore: AsyncLinkedLeafStore,
@@ -64,41 +63,11 @@ export class BatchProducerModule extends SequencerModule {
    * transactions that are present in the mempool. This function should also
    * be the one called by BlockTriggerss
    */
+  @ensureNotBusy()
   public async createBatch(
     blocks: BlockWithResult[]
   ): Promise<SettleableBatch | undefined> {
-    if (!this.productionInProgress) {
-      try {
-        this.productionInProgress = true;
-
-        const batch = await this.tryProduceBatch(blocks);
-
-        this.productionInProgress = false;
-
-        return batch;
-      } catch (error: unknown) {
-        this.productionInProgress = false;
-        // TODO Check if that still makes sense
-        if (error instanceof Error) {
-          if (
-            !error.message.includes(
-              "Can't create a block with zero transactions"
-            )
-          ) {
-            log.error(error);
-          }
-
-          throw error;
-        } else {
-          log.error(error);
-        }
-      }
-    } else {
-      log.debug(
-        "Skipping new block production because production is still in progress"
-      );
-    }
-    return undefined;
+    return await this.tryProduceBatch(blocks);
   }
 
   private async tryProduceBatch(

--- a/packages/sequencer/src/protocol/production/BatchProducerModule.ts
+++ b/packages/sequencer/src/protocol/production/BatchProducerModule.ts
@@ -61,16 +61,10 @@ export class BatchProducerModule extends SequencerModule {
   /**
    * Main function to call when wanting to create a new block based on the
    * transactions that are present in the mempool. This function should also
-   * be the one called by BlockTriggerss
+   * be the one called by BlockTriggers.
    */
-  public async createBatch(
-    blocks: BlockWithResult[]
-  ): Promise<SettleableBatch | undefined> {
-    return await this.tryProduceBatch(blocks);
-  }
-
   @ensureNotBusy()
-  private async tryProduceBatch(
+  public async createBatch(
     blocks: BlockWithResult[]
   ): Promise<SettleableBatch | undefined> {
     log.info("Producing batch...");

--- a/packages/sequencer/src/protocol/production/BatchProducerModule.ts
+++ b/packages/sequencer/src/protocol/production/BatchProducerModule.ts
@@ -68,7 +68,7 @@ export class BatchProducerModule extends SequencerModule {
   ): Promise<SettleableBatch | undefined> {
     return await this.tryProduceBatch(blocks);
   }
-  
+
   @ensureNotBusy()
   private async tryProduceBatch(
     blocks: BlockWithResult[]

--- a/packages/sequencer/src/protocol/production/sequencing/BlockProducerModule.ts
+++ b/packages/sequencer/src/protocol/production/sequencing/BlockProducerModule.ts
@@ -27,6 +27,7 @@ import { IncomingMessagesService } from "../../../settlement/messages/IncomingMe
 import { Tracer } from "../../../logging/Tracer";
 import { trace } from "../../../logging/trace";
 import { AsyncLinkedLeafStore } from "../../../state/async/AsyncLinkedLeafStore";
+import { ensureNotBusy } from "../../../helpers/BusyGuard";
 
 import { BlockProductionService } from "./BlockProductionService";
 import { BlockResultService } from "./BlockResultService";
@@ -38,8 +39,6 @@ export interface BlockConfig {
 
 @sequencerModule()
 export class BlockProducerModule extends SequencerModule<BlockConfig> {
-  private productionInProgress = false;
-
   public constructor(
     @inject("Mempool") private readonly mempool: Mempool,
     @inject("IncomingMessagesService", { isOptional: true })
@@ -140,37 +139,25 @@ export class BlockProducerModule extends SequencerModule<BlockConfig> {
     return result;
   }
 
+  @ensureNotBusy()
   public async tryProduceBlock(): Promise<Block | undefined> {
-    if (!this.productionInProgress) {
-      try {
-        const block = await this.produceBlock();
+    const block = await this.produceBlock();
 
-        if (block === undefined) {
-          if (!this.allowEmptyBlock()) {
-            log.info("No transactions in mempool, skipping production");
-          } else {
-            log.error("Something wrong happened, skipping block");
-          }
-          return undefined;
-        }
-
-        log.info(
-          `Produced block #${block.height.toBigInt()} (${block.transactions.length} txs)`
-        );
-        this.prettyPrintBlockContents(block);
-
-        return block;
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          throw error;
-        } else {
-          log.error(error);
-        }
-      } finally {
-        this.productionInProgress = false;
+    if (block === undefined) {
+      if (!this.allowEmptyBlock()) {
+        log.info("No transactions in mempool, skipping production");
+      } else {
+        log.error("Something wrong happened, skipping block");
       }
+      return undefined;
     }
-    return undefined;
+
+    log.info(
+      `Produced block #${block.height.toBigInt()} (${block.transactions.length} txs)`
+    );
+    this.prettyPrintBlockContents(block);
+
+    return block;
   }
 
   // TODO Move to different service, to remove dependency on mempool and messagequeue
@@ -220,8 +207,6 @@ export class BlockProducerModule extends SequencerModule<BlockConfig> {
 
   @trace("block")
   private async produceBlock(): Promise<Block | undefined> {
-    this.productionInProgress = true;
-
     const { txs, metadata } = await this.collectProductionData();
 
     // Skip production if no transactions are available for now
@@ -262,8 +247,6 @@ export class BlockProducerModule extends SequencerModule<BlockConfig> {
           .map((x) => x.hash)
       );
     }
-
-    this.productionInProgress = false;
 
     return blockResult?.block;
   }

--- a/packages/sequencer/src/protocol/production/trigger/TimedBlockTrigger.ts
+++ b/packages/sequencer/src/protocol/production/trigger/TimedBlockTrigger.ts
@@ -12,6 +12,7 @@ import {
   BridgingModule,
   SettlementTokenConfig,
 } from "../../../settlement/BridgingModule";
+import { ensureNotBusy } from "../../../helpers/BusyGuard";
 
 import { BlockEvents, BlockTriggerBase } from "./BlockTrigger";
 
@@ -44,9 +45,6 @@ export class TimedBlockTrigger
   // There is no real type for interval ids somehow, so any it is
 
   private interval?: any;
-
-  // TODO Move that logic to somewhere proper
-  private settlementInProgress = false;
 
   public constructor(
     @inject("BatchProducerModule", { isOptional: true })
@@ -123,15 +121,9 @@ export class TimedBlockTrigger
         // otherwise treat as unproven-only
         if (
           settlementInterval !== undefined &&
-          totalTime % settlementInterval === 0 &&
-          !this.settlementInProgress
+          totalTime % settlementInterval === 0
         ) {
-          this.settlementInProgress = true;
-          const batch = await this.produceBatch();
-          if (batch !== undefined) {
-            await this.settle(batch, this.config.settlementTokenConfig);
-          }
-          this.settlementInProgress = false;
+          await this.tryProduceSettlement();
         }
       } catch (error) {
         log.error(error);
@@ -148,6 +140,14 @@ export class TimedBlockTrigger
     // than 1 tx in mempool
     if (mempoolTxs.length > 0 || (this.config.produceEmptyBlocks ?? true)) {
       await this.produceBlock();
+    }
+  }
+
+  @ensureNotBusy()
+  private async tryProduceSettlement(): Promise<void> {
+    const batch = await this.produceBatch();
+    if (batch !== undefined) {
+      await this.settle(batch, this.config.settlementTokenConfig);
     }
   }
 

--- a/packages/sequencer/src/worker/queue/LocalTaskQueue.ts
+++ b/packages/sequencer/src/worker/queue/LocalTaskQueue.ts
@@ -3,6 +3,7 @@ import { log, mapSequential, noop, sleep } from "@proto-kit/common";
 import { sequencerModule } from "../../sequencer/builder/SequencerModule";
 import { TaskPayload } from "../flow/Task";
 import { Closeable } from "../../sequencer/builder/Closeable";
+import { ensureNotBusy } from "../../helpers/BusyGuard";
 
 import { InstantiatedQueue, TaskQueue } from "./TaskQueue";
 import { ListenerList } from "./ListenerList";
@@ -91,56 +92,50 @@ export class LocalTaskQueue
     [key: string]: QueueListener[] | undefined;
   } = {};
 
-  private taskInProgress = false;
-
+  @ensureNotBusy()
   public async workNextTasks() {
-    if (this.taskInProgress) {
-      return;
-    }
-    this.taskInProgress = true;
+    let hasMoreTasks = true;
 
-    // Collect all tasks
-    const tasksToExecute = Object.entries(this.queuedTasks).flatMap(
-      ([queueName, tasks]) => {
-        if (tasks.length > 0 && this.workers[queueName]) {
-          const functions = tasks.map((task) => async () => {
-            // Execute task in worker
+    while (hasMoreTasks) {
+      // Collect all tasks
+      const tasksToExecute = Object.entries(this.queuedTasks).flatMap(
+        ([queueName, tasks]) => {
+          if (tasks.length > 0 && this.workers[queueName]) {
+            const functions = tasks.map((task) => async () => {
+              // Execute task in worker
 
-            log.trace(`Working ${task.payload.name} with id ${task.taskId}`);
+              log.trace(`Working ${task.payload.name} with id ${task.taskId}`);
 
-            const payload = await this.workers[queueName]?.handler(
-              task.payload
-            );
+              const payload = await this.workers[queueName]?.handler(
+                task.payload
+              );
 
-            if (payload === "closed" || payload === undefined) {
-              return;
-            }
-            log.trace("LocalTaskQueue got", JSON.stringify(payload));
-
-            // Notify listeners about result
-            const listenerPromises = this.listeners[queueName]?.map(
-              async (listener) => {
-                await listener(payload);
+              if (payload === "closed" || payload === undefined) {
+                return;
               }
-            );
-            await Promise.all(listenerPromises || []);
-          });
-          this.queuedTasks[queueName] = [];
-          return functions;
+              log.trace("LocalTaskQueue got", JSON.stringify(payload));
+
+              // Notify listeners about result
+              const listenerPromises = this.listeners[queueName]?.map(
+                async (listener) => {
+                  await listener(payload);
+                }
+              );
+              await Promise.all(listenerPromises || []);
+            });
+            this.queuedTasks[queueName] = [];
+            return functions;
+          }
+
+          return [];
         }
+      );
 
-        return [];
-      }
-    );
+      // Execute all tasks
+      await mapSequential(tasksToExecute, async (task) => await task());
 
-    // Execute all tasks
-    await mapSequential(tasksToExecute, async (task) => await task());
-
-    this.taskInProgress = false;
-
-    // In case new tasks came up in the meantime, execute them as well
-    if (tasksToExecute.length > 0) {
-      await this.workNextTasks();
+      // Continue loop only if we processed tasks (more may have arrived)
+      hasMoreTasks = tasksToExecute.length > 0;
     }
   }
 

--- a/packages/sequencer/src/worker/queue/LocalTaskQueue.ts
+++ b/packages/sequencer/src/worker/queue/LocalTaskQueue.ts
@@ -97,7 +97,6 @@ export class LocalTaskQueue
     let hasMoreTasks = true;
 
     while (hasMoreTasks) {
-      // Collect all tasks
       const tasksToExecute = Object.entries(this.queuedTasks).flatMap(
         ([queueName, tasks]) => {
           if (tasks.length > 0 && this.workers[queueName]) {
@@ -118,6 +117,7 @@ export class LocalTaskQueue
               // Notify listeners about result
               const listenerPromises = this.listeners[queueName]?.map(
                 async (listener) => {
+                  // eslint-disable-next-line no-await-in-loop
                   await listener(payload);
                 }
               );

--- a/packages/sequencer/src/worker/queue/LocalTaskQueue.ts
+++ b/packages/sequencer/src/worker/queue/LocalTaskQueue.ts
@@ -3,7 +3,6 @@ import { log, mapSequential, noop, sleep } from "@proto-kit/common";
 import { sequencerModule } from "../../sequencer/builder/SequencerModule";
 import { TaskPayload } from "../flow/Task";
 import { Closeable } from "../../sequencer/builder/Closeable";
-import { ensureNotBusy } from "../../helpers/BusyGuard";
 
 import { InstantiatedQueue, TaskQueue } from "./TaskQueue";
 import { ListenerList } from "./ListenerList";
@@ -94,7 +93,7 @@ export class LocalTaskQueue
 
   private taskInProgress = false;
 
-public async workNextTasks() {
+  public async workNextTasks() {
     if (this.taskInProgress) {
       return;
     }

--- a/packages/sequencer/src/worker/queue/LocalTaskQueue.ts
+++ b/packages/sequencer/src/worker/queue/LocalTaskQueue.ts
@@ -92,50 +92,56 @@ export class LocalTaskQueue
     [key: string]: QueueListener[] | undefined;
   } = {};
 
-  @ensureNotBusy()
-  public async workNextTasks() {
-    let hasMoreTasks = true;
+  private taskInProgress = false;
 
-    while (hasMoreTasks) {
-      const tasksToExecute = Object.entries(this.queuedTasks).flatMap(
-        ([queueName, tasks]) => {
-          if (tasks.length > 0 && this.workers[queueName]) {
-            const functions = tasks.map((task) => async () => {
-              // Execute task in worker
+public async workNextTasks() {
+    if (this.taskInProgress) {
+      return;
+    }
+    this.taskInProgress = true;
 
-              log.trace(`Working ${task.payload.name} with id ${task.taskId}`);
+    // Collect all tasks
+    const tasksToExecute = Object.entries(this.queuedTasks).flatMap(
+      ([queueName, tasks]) => {
+        if (tasks.length > 0 && this.workers[queueName]) {
+          const functions = tasks.map((task) => async () => {
+            // Execute task in worker
 
-              const payload = await this.workers[queueName]?.handler(
-                task.payload
-              );
+            log.trace(`Working ${task.payload.name} with id ${task.taskId}`);
 
-              if (payload === "closed" || payload === undefined) {
-                return;
+            const payload = await this.workers[queueName]?.handler(
+              task.payload
+            );
+
+            if (payload === "closed" || payload === undefined) {
+              return;
+            }
+            log.trace("LocalTaskQueue got", JSON.stringify(payload));
+
+            // Notify listeners about result
+            const listenerPromises = this.listeners[queueName]?.map(
+              async (listener) => {
+                await listener(payload);
               }
-              log.trace("LocalTaskQueue got", JSON.stringify(payload));
-
-              // Notify listeners about result
-              const listenerPromises = this.listeners[queueName]?.map(
-                async (listener) => {
-                  // eslint-disable-next-line no-await-in-loop
-                  await listener(payload);
-                }
-              );
-              await Promise.all(listenerPromises || []);
-            });
-            this.queuedTasks[queueName] = [];
-            return functions;
-          }
-
-          return [];
+            );
+            await Promise.all(listenerPromises || []);
+          });
+          this.queuedTasks[queueName] = [];
+          return functions;
         }
-      );
 
-      // Execute all tasks
-      await mapSequential(tasksToExecute, async (task) => await task());
+        return [];
+      }
+    );
 
-      // Continue loop only if we processed tasks (more may have arrived)
-      hasMoreTasks = tasksToExecute.length > 0;
+    // Execute all tasks
+    await mapSequential(tasksToExecute, async (task) => await task());
+
+    this.taskInProgress = false;
+
+    // In case new tasks came up in the meantime, execute them as well
+    if (tasksToExecute.length > 0) {
+      await this.workNextTasks();
     }
   }
 


### PR DESCRIPTION
## Description

Previosuly, in modules like `BlockProducerModule` and `BatchProducerModule`, a boolean flag of `inProgress` was being used to check availability of module or production. It is changed with a decorator to make this checks, which replaces the repeated pattern. 

### Commits
- Implemented method decorator `@ensureNotBusy` for wrapping functions. 3c995cc
- Implemented it to various places 3c995cc 
    - Implemented a short private function for wrapping the block production operation, since only a short section of `start` function needs that check.
- Reverted use of @ensureNotBusy for `LocalTaskQueue`, since it was preventing use of recursion correctly. [602a492](https://github.com/proto-kit/framework/pull/399/commits/602a492bf71720b61d995f12302a30be7c97dabc)
    
    
Closes #324