### PR TITLE
feat(cli): add explorer stop command

### DIFF
--- a/packages/cli/src/commands/explorer/explorer.ts
+++ b/packages/cli/src/commands/explorer/explorer.ts
@@ -5,9 +5,11 @@ export const explorerCommand: CommandModule = {
   describe: "Explorer commands",
   builder: async (yargs) => {
     const { explorerStartCommand } = await import("./explorerStart");
+    const { explorerStopCommand } = await import("./explorerStop");
 
     return yargs
       .command(explorerStartCommand)
+      .command(explorerStopCommand)
       .demandCommand(
         1,
         "You must specify a subcommand. Use --help to see available options."

--- a/packages/cli/src/commands/explorer/explorerStop.ts
+++ b/packages/cli/src/commands/explorer/explorerStop.ts
@@ -1,0 +1,17 @@
+import { CommandModule } from "yargs";
+
+export const explorerStopCommand: CommandModule = {
+  command: "stop",
+  describe: "Stop the explorer UI",
+  handler: async () => {
+    try {
+      const { default: explorerStop } =
+        await import("../../scripts/explorer/stop");
+      await explorerStop();
+      process.exit(0);
+    } catch (error) {
+      console.error("Failed to stop explorer:", error);
+      process.exit(1);
+    }
+  },
+};

--- a/packages/cli/src/scripts/explorer/start.ts
+++ b/packages/cli/src/scripts/explorer/start.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 
+export const EXPLORER_CONTAINER_NAME = "protokit-explorer";
 const DEFAULT_EXPLORER_IMAGE = "ghcr.io/proto-kit/explorer:latest";
 
 async function pullDockerImage(image: string): Promise<void> {
@@ -40,7 +41,7 @@ async function runDockerContainer(args: {
     "-d",
     "--rm",
     "--name",
-    "protokit-explorer",
+    EXPLORER_CONTAINER_NAME,
     "-p",
     `${port}:3000`,
   ];

--- a/packages/cli/src/scripts/explorer/start.ts
+++ b/packages/cli/src/scripts/explorer/start.ts
@@ -44,7 +44,7 @@ async function runDockerContainer(args: {
     "-p",
     `${port}:3000`,
   ];
-  
+
   if (args.indexerUrl !== undefined) {
     dockerArgs.push("-e", `NEXT_PUBLIC_INDEXER_URL=${args.indexerUrl}`);
   }

--- a/packages/cli/src/scripts/explorer/start.ts
+++ b/packages/cli/src/scripts/explorer/start.ts
@@ -35,8 +35,16 @@ async function runDockerContainer(args: {
   const { port = 5003, explorerImage } = args;
   console.log(`\nExplorer is running at http://localhost:${port}\n`);
 
-  const dockerArgs = ["run", "--rm", "-p", `${port}:3000`];
-
+  const dockerArgs = [
+    "run",
+    "-d",
+    "--rm",
+    "--name",
+    "protokit-explorer",
+    "-p",
+    `${port}:3000`,
+  ];
+  
   if (args.indexerUrl !== undefined) {
     dockerArgs.push("-e", `NEXT_PUBLIC_INDEXER_URL=${args.indexerUrl}`);
   }

--- a/packages/cli/src/scripts/explorer/stop.ts
+++ b/packages/cli/src/scripts/explorer/stop.ts
@@ -1,4 +1,5 @@
 import { spawn } from "child_process";
+
 import { EXPLORER_CONTAINER_NAME } from "./start";
 
 async function stopDockerContainer(): Promise<void> {

--- a/packages/cli/src/scripts/explorer/stop.ts
+++ b/packages/cli/src/scripts/explorer/stop.ts
@@ -1,0 +1,37 @@
+import { spawn } from "child_process";
+
+const CONTAINER_NAME = "protokit-explorer";
+
+async function stopDockerContainer(): Promise<void> {
+  return await new Promise<void>((resolve, reject) => {
+    console.log(`Stopping explorer container...`);
+    const child = spawn("docker", ["stop", CONTAINER_NAME], {
+      stdio: "inherit",
+    });
+
+    child.on("error", (error) => {
+      console.error("Failed to stop explorer container:", error);
+      reject(error);
+    });
+
+    child.on("exit", (code) => {
+      if (code !== null && code !== 0) {
+        reject(
+          new Error(`Failed to stop explorer container (exit code ${code})`)
+        );
+      } else {
+        console.log("Explorer container stopped successfully");
+        resolve();
+      }
+    });
+  });
+}
+
+export default async function (): Promise<void> {
+  try {
+    await stopDockerContainer();
+  } catch (error) {
+    console.error("Failed to stop explorer:", error);
+    throw error;
+  }
+}

--- a/packages/cli/src/scripts/explorer/stop.ts
+++ b/packages/cli/src/scripts/explorer/stop.ts
@@ -4,7 +4,7 @@ const CONTAINER_NAME = "protokit-explorer";
 
 async function stopDockerContainer(): Promise<void> {
   return await new Promise<void>((resolve, reject) => {
-    console.log(`Stopping explorer container...`);
+    console.log("Stopping explorer container...");
     const child = spawn("docker", ["stop", CONTAINER_NAME], {
       stdio: "inherit",
     });

--- a/packages/cli/src/scripts/explorer/stop.ts
+++ b/packages/cli/src/scripts/explorer/stop.ts
@@ -1,11 +1,10 @@
 import { spawn } from "child_process";
-
-const CONTAINER_NAME = "protokit-explorer";
+import { EXPLORER_CONTAINER_NAME } from "./start";
 
 async function stopDockerContainer(): Promise<void> {
   return await new Promise<void>((resolve, reject) => {
     console.log("Stopping explorer container...");
-    const child = spawn("docker", ["stop", CONTAINER_NAME], {
+    const child = spawn("docker", ["stop", EXPLORER_CONTAINER_NAME], {
       stdio: "inherit",
     });
 


### PR DESCRIPTION
closes #443. 

**Changes:**

- Run the explorer Docker container in detached mode.
- Add explorer stop CLI command to stop the running container.

**Usage:**

```
npx protokit explorer start  
npx protokit explorer stop 
```