### PR TITLE
Fix missing sideloaded feature flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29412,7 +29412,8 @@
         "lodash-es": "^4.17.21",
         "mina-fungible-token": "^1.1.0",
         "reflect-metadata": "^0.1.13",
-        "ts-pattern": "^4.3.0"
+        "ts-pattern": "^4.3.0",
+        "typescript-memoize": "^1.1.1"
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",

--- a/packages/common/src/compiling/services/ChildVerificationKeyService.ts
+++ b/packages/common/src/compiling/services/ChildVerificationKeyService.ts
@@ -1,5 +1,4 @@
 import { injectable, Lifecycle, scoped } from "tsyringe";
-import { Provable } from "o1js";
 
 import { CompileRegistry } from "../CompileRegistry";
 
@@ -30,7 +29,6 @@ export class ChildVerificationKeyService {
     if (!vk.hash.isConstant()) {
       throw new Error("Sanity check - vk hash has to be constant");
     }
-    Provable.log("Vk hash", name, vk.hash, vk.data);
     return vk;
   }
 }

--- a/packages/common/src/compiling/services/ChildVerificationKeyService.ts
+++ b/packages/common/src/compiling/services/ChildVerificationKeyService.ts
@@ -1,4 +1,5 @@
 import { injectable, Lifecycle, scoped } from "tsyringe";
+import { Provable } from "o1js";
 
 import { CompileRegistry } from "../CompileRegistry";
 
@@ -29,6 +30,7 @@ export class ChildVerificationKeyService {
     if (!vk.hash.isConstant()) {
       throw new Error("Sanity check - vk hash has to be constant");
     }
+    Provable.log("Vk hash", name, vk.hash, vk.data);
     return vk;
   }
 }

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -311,3 +311,10 @@ export function assertDefined<T>(
     throw new Error(msg ?? "Value is undefined");
   }
 }
+
+export function takeFirst<T>(arr: T[]): T {
+  if (arr.length === 0) {
+    throw new Error("takeFirst called with empty array");
+  }
+  return arr[0];
+}

--- a/packages/common/src/zkProgrammable/FeatureFlagsExtension.ts
+++ b/packages/common/src/zkProgrammable/FeatureFlagsExtension.ts
@@ -1,0 +1,27 @@
+import { FeatureFlags } from "o1js";
+
+function combineFeatureFlag(a: boolean | undefined, b: boolean | undefined) {
+  if (a === true || b === true) {
+    return true;
+  } else if (a === undefined || b === undefined) {
+    return undefined;
+  } else {
+    return false;
+  }
+}
+
+export function combineFeatureFlags(
+  a: FeatureFlags,
+  b: FeatureFlags
+): FeatureFlags {
+  return {
+    xor: combineFeatureFlag(a.xor, b.xor),
+    rot: combineFeatureFlag(a.rot, b.rot),
+    lookup: combineFeatureFlag(a.lookup, b.lookup),
+    foreignFieldAdd: combineFeatureFlag(a.foreignFieldAdd, b.foreignFieldAdd),
+    foreignFieldMul: combineFeatureFlag(a.foreignFieldMul, b.foreignFieldMul),
+    rangeCheck0: combineFeatureFlag(a.rangeCheck0, b.rangeCheck0),
+    rangeCheck1: combineFeatureFlag(a.rangeCheck1, b.rangeCheck1),
+    runtimeTables: combineFeatureFlag(a.runtimeTables, b.runtimeTables),
+  };
+}

--- a/packages/common/src/zkProgrammable/ZkProgrammable.ts
+++ b/packages/common/src/zkProgrammable/ZkProgrammable.ts
@@ -5,15 +5,19 @@ import {
   Field,
   Provable,
   Cache as O1Cache,
+  DynamicProof,
+  FlexibleProvable,
+  FeatureFlags,
 } from "o1js";
 import { Memoize } from "typescript-memoize";
 
 import { log } from "../log";
 import { dummyVerificationKey } from "../dummyVerificationKey";
-import { reduceSequential } from "../utils";
+import { mapSequential, reduceSequential } from "../utils";
 import type { CompileRegistry } from "../compiling/CompileRegistry";
 
 import { MOCK_PROOF } from "./provableMethod";
+import { combineFeatureFlags } from "./FeatureFlagsExtension";
 
 const errors = {
   areProofsEnabledNotSet: (name: string) =>
@@ -52,6 +56,8 @@ export interface PlainZkProgram<
   PublicOutput = undefined,
 > {
   name: string;
+  publicInputType: FlexibleProvable<PublicInput>;
+  publicOutputType: FlexibleProvable<PublicOutput>;
   compile: Compile;
   verify: Verify<PublicInput, PublicOutput>;
   Proof: ReturnType<
@@ -75,8 +81,15 @@ export interface PlainZkProgram<
       }>)
   >;
   analyzeMethods: () => Promise<
-    Record<string, Awaited<ReturnType<typeof Provable.constraintSystem>>>
+    Record<
+      string,
+      Awaited<ReturnType<typeof Provable.constraintSystem>> & {
+        // TODO Properly model ProofClass here
+        proofs: any[];
+      }
+    >
   >;
+  maxProofsVerified: () => Promise<0 | 1 | 2>;
 }
 
 export function verifyToMockable<PublicInput, PublicOutput>(
@@ -125,17 +138,18 @@ export abstract class ZkProgrammable<
 > {
   public abstract get areProofsEnabled(): AreProofsEnabled | undefined;
 
-  public abstract zkProgramFactory(): PlainZkProgram<
-    PublicInput,
-    PublicOutput
-  >[];
+  public abstract zkProgramFactory(): Promise<
+    PlainZkProgram<PublicInput, PublicOutput>[]
+  >;
 
   private zkProgramSingleton?: PlainZkProgram<PublicInput, PublicOutput>[];
 
   @Memoize()
-  public get zkProgram(): PlainZkProgram<PublicInput, PublicOutput>[] {
+  public async zkProgram(): Promise<
+    PlainZkProgram<PublicInput, PublicOutput>[]
+  > {
     if (this.zkProgramSingleton === undefined) {
-      this.zkProgramSingleton = this.zkProgramFactory();
+      this.zkProgramSingleton = await this.zkProgramFactory();
     }
 
     return this.zkProgramSingleton.map((bucket) => {
@@ -150,9 +164,62 @@ export abstract class ZkProgrammable<
     });
   }
 
+  public async proofType(): Promise<typeof Proof<PublicInput, PublicOutput>> {
+    const programs = await this.zkProgram();
+
+    const Template = programs[0].Proof;
+    const maxProofsVerifeds = await mapSequential(programs, (p) =>
+      p.maxProofsVerified()
+    );
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const maxProofsVerified = Math.max(...maxProofsVerifeds) as 0 | 1 | 2;
+
+    return class ZkProgrammableProofType extends Proof<
+      PublicInput,
+      PublicOutput
+    > {
+      static publicInputType = Template.publicInputType;
+
+      static publicOutputType = Template.publicOutputType;
+
+      static maxProofsVerified = maxProofsVerified;
+    };
+  }
+
+  public async dynamicProofType(): Promise<
+    typeof DynamicProof<PublicInput, PublicOutput>
+  > {
+    const programs = await this.zkProgram();
+
+    const maxProofsVerifieds = await mapSequential(
+      programs,
+      async (zkProgram) => await zkProgram.maxProofsVerified()
+    );
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const maxProofsVerified = Math.max(...maxProofsVerifieds) as 0 | 1 | 2;
+    const featureFlagss = await mapSequential(
+      programs,
+      async (zkProgram) => await FeatureFlags.fromZkProgram(zkProgram)
+    );
+    const featureFlags = featureFlagss.reduce(combineFeatureFlags);
+
+    return class DynamicProofType extends DynamicProof<
+      PublicInput,
+      PublicOutput
+    > {
+      static publicInputType = programs[0].publicInputType;
+
+      static publicOutputType = programs[0].publicOutputType;
+
+      static maxProofsVerified = maxProofsVerified;
+
+      static featureFlags = featureFlags;
+    };
+  }
+
   public async compile(registry: CompileRegistry) {
     return await reduceSequential(
-      this.zkProgram,
+      await this.zkProgram(),
       async (acc, program) => {
         const result = await registry.compile(program);
         return {

--- a/packages/common/src/zkProgrammable/ZkProgrammable.ts
+++ b/packages/common/src/zkProgrammable/ZkProgrammable.ts
@@ -231,9 +231,9 @@ export abstract class ZkProgrammable<
   }
 
   public async compile(registry: CompileRegistry) {
-    const program = await this.zkProgram();
+    const programs = await this.zkProgram();
     return await reduceSequential(
-      program,
+      programs,
       async (acc, program) => {
         const result = await registry.compile(program);
         return {

--- a/packages/common/src/zkProgrammable/ZkProgrammable.ts
+++ b/packages/common/src/zkProgrammable/ZkProgrammable.ts
@@ -164,6 +164,7 @@ export abstract class ZkProgrammable<
     });
   }
 
+  @Memoize()
   public async proofType(): Promise<typeof Proof<PublicInput, PublicOutput>> {
     const programs = await this.zkProgram();
 
@@ -186,22 +187,34 @@ export abstract class ZkProgrammable<
     };
   }
 
+  @Memoize()
   public async dynamicProofType(): Promise<
     typeof DynamicProof<PublicInput, PublicOutput>
   > {
     const programs = await this.zkProgram();
 
-    const maxProofsVerifieds = await mapSequential(
-      programs,
-      async (zkProgram) => await zkProgram.maxProofsVerified()
-    );
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const maxProofsVerified = Math.max(...maxProofsVerifieds) as 0 | 1 | 2;
-    const featureFlagss = await mapSequential(
-      programs,
-      async (zkProgram) => await FeatureFlags.fromZkProgram(zkProgram)
-    );
-    const featureFlags = featureFlagss.reduce(combineFeatureFlags);
+    let maxProofsVerified: 0 | 1 | 2;
+    let featureFlags: FeatureFlags;
+
+    // We actually only need to compute maxProofsVerified and featuresflags if proofs
+    // are enabled, otherwise o1js will ignore it anyways. This way startup is a bit
+    // faster for non-proof environments
+    if (this.areProofsEnabled?.areProofsEnabled === true) {
+      const maxProofsVerifieds = await mapSequential(
+        programs,
+        async (zkProgram) => await zkProgram.maxProofsVerified()
+      );
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      maxProofsVerified = Math.max(...maxProofsVerifieds) as 0 | 1 | 2;
+      const featureFlagsSet = await mapSequential(
+        programs,
+        async (zkProgram) => await FeatureFlags.fromZkProgram(zkProgram)
+      );
+      featureFlags = featureFlagsSet.reduce(combineFeatureFlags);
+    } else {
+      featureFlags = FeatureFlags.allNone;
+      maxProofsVerified = 0;
+    }
 
     return class DynamicProofType extends DynamicProof<
       PublicInput,

--- a/packages/common/src/zkProgrammable/ZkProgrammable.ts
+++ b/packages/common/src/zkProgrammable/ZkProgrammable.ts
@@ -218,8 +218,9 @@ export abstract class ZkProgrammable<
   }
 
   public async compile(registry: CompileRegistry) {
+    const program = await this.zkProgram();
     return await reduceSequential(
-      await this.zkProgram(),
+      program,
       async (acc, program) => {
         const result = await registry.compile(program);
         return {

--- a/packages/common/src/zkProgrammable/provableMethod.ts
+++ b/packages/common/src/zkProgrammable/provableMethod.ts
@@ -26,7 +26,7 @@ export function toProver(
   return async function prover(this: ZkProgrammable<any, any>) {
     const { areProofsEnabled } = this.areProofsEnabled!;
 
-    const zkProgram = this.zkProgram.find((prog) =>
+    const zkProgram = (await this.zkProgram()).find((prog) =>
       Object.keys(prog.methods).includes(methodName)
     );
 

--- a/packages/common/test/zkProgrammable/ZkProgrammable.test.ts
+++ b/packages/common/test/zkProgrammable/ZkProgrammable.test.ts
@@ -11,6 +11,7 @@ import {
   MOCK_VERIFICATION_KEY,
   ZkProgrammable,
   ProvableMethodExecutionContext,
+  takeFirst,
 } from "../../src";
 
 const appChainMock: AreProofsEnabled = {
@@ -60,7 +61,7 @@ class TestProgrammable extends ZkProgrammable<
     };
   }
 
-  public zkProgramFactory() {
+  public async zkProgramFactory() {
     const program = ZkProgram({
       name: "testprogram",
       publicInput: TestPublicInput,
@@ -89,9 +90,12 @@ class TestProgrammable extends ZkProgrammable<
     return [
       {
         name: program.name,
+        publicInputType: program.publicInputType,
+        publicOutputType: program.publicOutputType,
         compile: program.compile.bind(program),
         verify: program.verify.bind(program),
         analyzeMethods: program.analyzeMethods.bind(program),
+        maxProofsVerified: program.maxProofsVerified.bind(program),
         Proof: SelfProof,
         methods,
       },
@@ -106,19 +110,21 @@ class OtherTestProgrammable extends ZkProgrammable<undefined, void> {
     super();
   }
 
-  proofType = this.testProgrammable.zkProgram[0].Proof;
-
   @provableMethod()
-  public async bar(testProgrammableProof: InstanceType<typeof this.proofType>) {
+  public async bar(
+    testProgrammableProof: InstanceType<
+      Awaited<ReturnType<typeof this.testProgrammable.proofType>>
+    >
+  ) {
     testProgrammableProof.verify();
   }
 
-  public zkProgramFactory() {
+  public async zkProgramFactory() {
     const program = ZkProgram({
       name: "testprogram2",
       methods: {
         bar: {
-          privateInputs: [this.testProgrammable.zkProgram[0].Proof],
+          privateInputs: [await this.testProgrammable.proofType()],
           method: this.bar.bind(this),
         },
       },
@@ -133,9 +139,12 @@ class OtherTestProgrammable extends ZkProgrammable<undefined, void> {
     return [
       {
         name: program.name,
+        publicInputType: program.publicInputType,
+        publicOutputType: program.publicOutputType,
         compile: program.compile.bind(program),
         verify: program.verify.bind(program),
         analyzeMethods: program.analyzeMethods.bind(program),
+        maxProofsVerified: program.maxProofsVerified.bind(program),
         Proof: SelfProof,
         methods,
       },
@@ -189,7 +198,13 @@ describe("zkProgrammable", () => {
         testProgrammable = new TestProgrammable();
         testProgrammable.areProofsEnabled.setProofsEnabled(areProofsEnabled);
         zkProgramFactorySpy = jest.spyOn(testProgrammable, "zkProgramFactory");
-        artifact = await testProgrammable.zkProgram[0].compile();
+
+        const o = await testProgrammable.zkProgram();
+
+        artifact = await testProgrammable
+          .zkProgram()
+          .then((p) => takeFirst(p))
+          .then((p) => p.compile());
       }, 500_000);
 
       describe("zkProgramFactory", () => {
@@ -216,7 +231,8 @@ describe("zkProgrammable", () => {
       it("if proofs are disabled, it should successfully verify mock proofs", async () => {
         expect.assertions(1);
 
-        const proof = new testProgrammable.zkProgram[0].Proof({
+        const program = await testProgrammable.zkProgram().then(takeFirst);
+        const proof = new program.Proof({
           proof: MOCK_PROOF,
 
           publicInput: new TestPublicInput({
@@ -230,7 +246,7 @@ describe("zkProgrammable", () => {
           maxProofsVerified: 0,
         });
 
-        const verified = await testProgrammable.zkProgram[0].verify(proof);
+        const verified = await program.verify(proof);
 
         expect(verified).toBe(shouldVerifyMockProofs);
 
@@ -254,7 +270,10 @@ describe("zkProgrammable", () => {
         describe("zkProgram interoperability", () => {
           beforeAll(async () => {
             otherTestProgrammable = new OtherTestProgrammable(testProgrammable);
-            await otherTestProgrammable.zkProgram[0].compile();
+            await otherTestProgrammable
+              .zkProgram()
+              .then(takeFirst)
+              .then((p) => p.compile());
           }, 500_000);
 
           it("should successfully pass proof of one zkProgram as input to another zkProgram", async () => {
@@ -267,8 +286,10 @@ describe("zkProgrammable", () => {
             const testProof = await executionContext
               .current()
               .result.prove<Proof<TestPublicInput, TestPublicOutput>>();
-            const testProofVerified =
-              await testProgrammable.zkProgram[0].verify(testProof);
+            const zkProgram = await testProgrammable
+              .zkProgram()
+              .then(takeFirst);
+            const testProofVerified = await zkProgram.verify(testProof);
 
             // execute bar
             await otherTestProgrammable.bar(testProof);
@@ -277,8 +298,11 @@ describe("zkProgrammable", () => {
             const otherTestProof = await executionContext
               .current()
               .result.prove<Proof<undefined, undefined>>();
+            const otherZkProgram = await otherTestProgrammable
+              .zkProgram()
+              .then(takeFirst);
             const otherTestProofVerified =
-              await otherTestProgrammable.zkProgram[0].verify(otherTestProof);
+              await otherZkProgram.verify(otherTestProof);
 
             expect(testProof.publicOutput.bar.toString()).toBe(
               testPublicInput.foo.toString()

--- a/packages/common/test/zkProgrammable/ZkProgrammable.test.ts
+++ b/packages/common/test/zkProgrammable/ZkProgrammable.test.ts
@@ -199,8 +199,6 @@ describe("zkProgrammable", () => {
         testProgrammable.areProofsEnabled.setProofsEnabled(areProofsEnabled);
         zkProgramFactorySpy = jest.spyOn(testProgrammable, "zkProgramFactory");
 
-        const o = await testProgrammable.zkProgram();
-
         artifact = await testProgrammable
           .zkProgram()
           .then((p) => takeFirst(p))

--- a/packages/library/src/hooks/RuntimeFeeAnalyzerService.ts
+++ b/packages/library/src/hooks/RuntimeFeeAnalyzerService.ts
@@ -82,66 +82,66 @@ export class RuntimeFeeAnalyzerService extends ConfigurableModule<RuntimeFeeAnal
     context.clear();
 
     let methodCounter = 0;
-    const [values, indexes] =
-      await this.runtime.zkProgrammable.zkProgram.reduce<
-        Promise<[FeeTreeValues, FeeIndexes]>
-      >(
-        async (accum, program) => {
-          const [valuesProg, indexesProg] = await accum;
-          const analyzedMethods = await program.analyzeMethods();
-          const [valuesMeth, indexesMeth] = Object.keys(program.methods).reduce<
-            [FeeTreeValues, FeeIndexes]
-          >(
-            // eslint-disable-next-line @typescript-eslint/no-shadow
-            ([values, indexes], combinedMethodName) => {
-              const { rows } = analyzedMethods[combinedMethodName];
-              // const rows = 1000;
-              const [moduleName, methodName] = combinedMethodName.split(".");
-              const methodId = this.runtime.methodIdResolver.getMethodId(
-                moduleName,
-                methodName
-              );
+    const programs = await this.runtime.zkProgrammable.zkProgram();
+    const [values, indexes] = await programs.reduce<
+      Promise<[FeeTreeValues, FeeIndexes]>
+    >(
+      async (accum, program) => {
+        const [valuesProg, indexesProg] = await accum;
+        const analyzedMethods = await program.analyzeMethods();
+        const [valuesMeth, indexesMeth] = Object.keys(program.methods).reduce<
+          [FeeTreeValues, FeeIndexes]
+        >(
+          // eslint-disable-next-line @typescript-eslint/no-shadow
+          ([values, indexes], combinedMethodName) => {
+            const { rows } = analyzedMethods[combinedMethodName];
+            // const rows = 1000;
+            const [moduleName, methodName] = combinedMethodName.split(".");
+            const methodId = this.runtime.methodIdResolver.getMethodId(
+              moduleName,
+              methodName
+            );
 
-              /**
-               * Determine the fee config for the given method id, and merge it with
-               * the default fee config.
-               */
-              return [
-                {
-                  ...values,
+            /**
+             * Determine the fee config for the given method id, and merge it with
+             * the default fee config.
+             */
+            return [
+              {
+                ...values,
 
-                  [methodId.toString()]: {
-                    methodId,
+                [methodId.toString()]: {
+                  methodId,
 
-                    baseFee:
-                      this.config.methods[combinedMethodName]?.baseFee ??
-                      this.config.baseFee,
+                  baseFee:
+                    this.config.methods[combinedMethodName]?.baseFee ??
+                    this.config.baseFee,
 
-                    perWeightUnitFee:
-                      this.config.methods[combinedMethodName]
-                        ?.perWeightUnitFee ?? this.config.perWeightUnitFee,
+                  perWeightUnitFee:
+                    this.config.methods[combinedMethodName]?.perWeightUnitFee ??
+                    this.config.perWeightUnitFee,
 
-                    weight:
-                      this.config.methods[combinedMethodName]?.weight ??
-                      BigInt(rows),
-                  },
+                  weight:
+                    this.config.methods[combinedMethodName]?.weight ??
+                    BigInt(rows),
                 },
-                {
-                  ...indexes,
-                  // eslint-disable-next-line no-plusplus
-                  [methodId.toString()]: BigInt(methodCounter++),
-                },
-              ];
-            },
-            [{}, {}]
-          );
-          return [
-            { ...valuesProg, ...valuesMeth },
-            { ...indexesProg, ...indexesMeth },
-          ];
-        },
-        Promise.resolve([{}, {}])
-      );
+              },
+              {
+                ...indexes,
+                // eslint-disable-next-line no-plusplus
+                [methodId.toString()]: BigInt(methodCounter++),
+              },
+            ];
+          },
+          [{}, {}]
+        );
+        return [
+          { ...valuesProg, ...valuesMeth },
+          { ...indexesProg, ...indexesMeth },
+        ];
+      },
+      Promise.resolve([{}, {}])
+    );
 
     const tree = new FeeTree(new InMemoryMerkleTreeStorage());
 

--- a/packages/module/src/runtime/Runtime.ts
+++ b/packages/module/src/runtime/Runtime.ts
@@ -76,7 +76,9 @@ export class RuntimeZkProgrammable<
     return this.runtime.areProofsEnabled;
   }
 
-  public zkProgramFactory(): PlainZkProgram<undefined, MethodPublicOutput>[] {
+  public async zkProgramFactory(): Promise<
+    PlainZkProgram<undefined, MethodPublicOutput>[]
+  > {
     type Methods = Record<
       string,
       {
@@ -253,9 +255,12 @@ export class RuntimeZkProgrammable<
 
       return {
         name,
+        publicInputType: program.publicInputType,
+        publicOutputType: program.publicOutputType,
         compile: program.compile.bind(program),
         verify: program.verify.bind(program),
         analyzeMethods: program.analyzeMethods.bind(program),
+        maxProofsVerified: program.maxProofsVerified.bind(program),
         Proof: SelfProof,
         methods,
       };

--- a/packages/module/test/modules/Balances.test.ts
+++ b/packages/module/test/modules/Balances.test.ts
@@ -81,7 +81,8 @@ describe("balances", () => {
         "1439144406936083177718146178121957896974210157062549589517697792374542035761";
       const expectedStatus = true;
 
-      await runtime.zkProgrammable.zkProgram[0].compile();
+      const runtimeProgram = await runtime.zkProgrammable.zkProgram();
+      await runtimeProgram[0].compile();
 
       await balances.getTotalSupply();
 
@@ -89,7 +90,7 @@ describe("balances", () => {
 
       const proof = await result.prove<Proof<undefined, MethodPublicOutput>>();
 
-      const verified = await runtime.zkProgrammable.zkProgram[0].verify(proof);
+      const verified = await runtimeProgram[0].verify(proof);
 
       runtime.zkProgrammable.areProofsEnabled?.setProofsEnabled(false);
 

--- a/packages/protocol/src/prover/block/BlockProvable.ts
+++ b/packages/protocol/src/prover/block/BlockProvable.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line max-classes-per-file
 import {
   Bool,
   DynamicProof,
@@ -360,27 +359,15 @@ export class BlockProverState {
   }
 }
 
-export class DynamicSTProof extends DynamicProof<
+export type DynamicSTProof = DynamicProof<
   StateTransitionProverPublicInput,
   StateTransitionProverPublicOutput
-> {
-  static publicInputType = StateTransitionProverPublicInput;
+>;
 
-  static publicOutputType = StateTransitionProverPublicOutput;
-
-  static maxProofsVerified = 2 as const;
-}
-
-export class DynamicTransactionProof extends DynamicProof<
+export type DynamicTransactionProof = DynamicProof<
   TransactionProverPublicInput,
   TransactionProverPublicOutput
-> {
-  static publicInputType = TransactionProverPublicInput;
-
-  static publicOutputType = TransactionProverPublicOutput;
-
-  static maxProofsVerified = 2 as const;
-}
+>;
 
 export type BlockProof = Proof<BlockProverPublicInput, BlockProverPublicOutput>;
 

--- a/packages/protocol/src/prover/block/BlockProver.ts
+++ b/packages/protocol/src/prover/block/BlockProver.ts
@@ -75,6 +75,14 @@ export class BlockProverProgrammable extends ZkProgrammable<
 > {
   public constructor(
     private readonly prover: BlockProver,
+    public readonly stateTransitionProver: ZkProgrammable<
+      StateTransitionProverPublicInput,
+      StateTransitionProverPublicOutput
+    >,
+    public readonly transactionProver: ZkProgrammable<
+      TransactionProverPublicInput,
+      TransactionProverPublicOutput
+    >,
     private readonly blockHooks: ProvableBlockHook<unknown>[],
     private readonly stateServiceProvider: StateServiceProvider,
     private readonly childVerificationKeyService: ChildVerificationKeyService
@@ -232,7 +240,8 @@ export class BlockProverProgrammable extends ZkProgrammable<
     const stProofVk = this.childVerificationKeyService.getAsConstant(
       "StateTransitionProver"
     );
-    stateTransitionProof.verifyIf(stProofVk, verifyStProof);
+    // stateTransitionProof.verifyIf(stProofVk, verifyStProof);
+    stateTransitionProof.verify(stProofVk);
 
     // Apply STProof if not deferred
     const stateProofResult = this.includeSTProof(
@@ -259,10 +268,9 @@ export class BlockProverProgrammable extends ZkProgrammable<
     );
 
     // Brought in as a constant
-    const transactionProofVk = this.childVerificationKeyService.getAsConstant(
-      "StateTransitionProver"
-    );
-    transactionProof.verifyIf(transactionProofVk, verifyTransactionProof);
+    const transactionProofVk =
+      this.childVerificationKeyService.getAsConstant("TransactionProver");
+    transactionProof.verify(transactionProofVk);
 
     // Fast-forward transaction trackers by the results of the aggregated transaction proof
     // Implicitly, the 'from' values here are asserted against the publicInput, since the hashlists
@@ -435,6 +443,7 @@ export class BlockProverProgrammable extends ZkProgrammable<
     deferSTProof: Bool,
     deferTransactionProof: Bool,
     finalize: Bool,
+    // TODO Add typing such that it is clear that either both are undefined or none is
     stateTransitionProof?: DynamicSTProof,
     transactionProof?: DynamicTransactionProof
   ): Promise<BlockProverPublicOutput> {
@@ -620,15 +629,18 @@ export class BlockProverProgrammable extends ZkProgrammable<
    * Recursive linking of proofs is done via the previously
    * injected StateTransitionProver and the required AppChainProof class
    */
-  public zkProgramFactory(): PlainZkProgram<
-    BlockProverPublicInput,
-    BlockProverPublicOutput
-  >[] {
+  public async zkProgramFactory(): Promise<
+    PlainZkProgram<BlockProverPublicInput, BlockProverPublicOutput>[]
+  > {
     const { prover } = this;
     const proveBlockBatchWithProofs =
       prover.proveBlockBatchWithProofs.bind(prover);
     const proveBlockBatchNoProofs = prover.proveBlockBatchNoProofs.bind(prover);
     const merge = prover.merge.bind(prover);
+
+    const dynamicStProofType =
+      await this.stateTransitionProver.dynamicProofType();
+    const dynamicTxProofType = await this.transactionProver.dynamicProofType();
 
     const program = ZkProgram({
       name: "BlockProver",
@@ -644,8 +656,8 @@ export class BlockProverProgrammable extends ZkProgrammable<
             BlockArgumentsBatch,
             Bool,
             Bool,
-            DynamicSTProof,
-            DynamicTransactionProof,
+            dynamicStProofType,
+            dynamicTxProofType,
           ],
           async method(
             publicInput: BlockProverPublicInput,
@@ -731,11 +743,14 @@ export class BlockProverProgrammable extends ZkProgrammable<
     return [
       {
         name: program.name,
+        publicInputType: program.publicInputType,
+        publicOutputType: program.publicOutputType,
         compile: program.compile.bind(program),
         verify: program.verify.bind(program),
         analyzeMethods: program.analyzeMethods.bind(program),
         Proof: SelfProofClass,
         methods,
+        maxProofsVerified: program.maxProofsVerified.bind(program),
       },
     ];
   }
@@ -775,6 +790,8 @@ export class BlockProver
     super();
     this.zkProgrammable = new BlockProverProgrammable(
       this,
+      stateTransitionProver.zkProgrammable,
+      transactionProver.zkProgrammable,
       blockHooks,
       stateServiceProvider,
       childVerificationKeyService

--- a/packages/protocol/src/prover/block/BlockProver.ts
+++ b/packages/protocol/src/prover/block/BlockProver.ts
@@ -240,8 +240,7 @@ export class BlockProverProgrammable extends ZkProgrammable<
     const stProofVk = this.childVerificationKeyService.getAsConstant(
       "StateTransitionProver"
     );
-    // stateTransitionProof.verifyIf(stProofVk, verifyStProof);
-    stateTransitionProof.verify(stProofVk);
+    stateTransitionProof.verifyIf(stProofVk, verifyStProof);
 
     // Apply STProof if not deferred
     const stateProofResult = this.includeSTProof(
@@ -270,7 +269,7 @@ export class BlockProverProgrammable extends ZkProgrammable<
     // Brought in as a constant
     const transactionProofVk =
       this.childVerificationKeyService.getAsConstant("TransactionProver");
-    transactionProof.verify(transactionProofVk);
+    transactionProof.verifyIf(transactionProofVk, verifyTransactionProof);
 
     // Fast-forward transaction trackers by the results of the aggregated transaction proof
     // Implicitly, the 'from' values here are asserted against the publicInput, since the hashlists

--- a/packages/protocol/src/prover/statetransition/StateTransitionProver.ts
+++ b/packages/protocol/src/prover/statetransition/StateTransitionProver.ts
@@ -74,10 +74,12 @@ export class StateTransitionProverProgrammable extends ZkProgrammable<
     return this.stateTransitionProver.areProofsEnabled;
   }
 
-  public zkProgramFactory(): PlainZkProgram<
-    StateTransitionProverPublicInput,
-    StateTransitionProverPublicOutput
-  >[] {
+  public async zkProgramFactory(): Promise<
+    PlainZkProgram<
+      StateTransitionProverPublicInput,
+      StateTransitionProverPublicOutput
+    >[]
+  > {
     const instance = this;
 
     const program = ZkProgram({
@@ -144,6 +146,9 @@ export class StateTransitionProverProgrammable extends ZkProgrammable<
         analyzeMethods: program.analyzeMethods.bind(program),
         Proof: SelfProofClass,
         methods,
+        publicInputType: program.publicInputType,
+        publicOutputType: program.publicOutputType,
+        maxProofsVerified: program.maxProofsVerified.bind(program),
       },
     ];
   }

--- a/packages/protocol/src/prover/transaction/TransactionProver.ts
+++ b/packages/protocol/src/prover/transaction/TransactionProver.ts
@@ -72,6 +72,7 @@ export class TransactionProverZkProgrammable extends ZkProgrammable<
 > {
   public constructor(
     private readonly prover: TransactionProver,
+    public readonly runtime: WithZkProgrammable<undefined, MethodPublicOutput>,
     private readonly transactionHooks: ProvableTransactionHook<unknown>[],
     private readonly stateServiceProvider: StateServiceProvider,
     private readonly verificationKeyService: MinimalVKTreeService
@@ -366,15 +367,20 @@ export class TransactionProverZkProgrammable extends ZkProgrammable<
    * Recursive linking of proofs is done via the previously
    * injected StateTransitionProver and the required AppChainProof class
    */
-  public zkProgramFactory(): PlainZkProgram<
-    TransactionProverPublicInput,
-    TransactionProverPublicOutput
-  >[] {
+  public async zkProgramFactory(): Promise<
+    PlainZkProgram<
+      TransactionProverPublicInput,
+      TransactionProverPublicOutput
+    >[]
+  > {
     const { prover } = this;
     const proveTransaction = prover.proveTransaction.bind(prover);
     const proveTransactions = prover.proveTransactions.bind(prover);
     const merge = prover.merge.bind(prover);
     const dummy = prover.dummy.bind(prover);
+
+    const runtimeProofType =
+      await this.runtime.zkProgrammable.dynamicProofType();
 
     const program = ZkProgram({
       name: "TransactionProver",
@@ -383,7 +389,7 @@ export class TransactionProverZkProgrammable extends ZkProgrammable<
 
       methods: {
         proveTransaction: {
-          privateInputs: [DynamicRuntimeProof, TransactionProverExecutionData],
+          privateInputs: [runtimeProofType, TransactionProverExecutionData],
 
           async method(
             publicInput: TransactionProverPublicInput,
@@ -469,9 +475,12 @@ export class TransactionProverZkProgrammable extends ZkProgrammable<
     return [
       {
         name: program.name,
+        publicInputType: program.publicInputType,
+        publicOutputType: program.publicOutputType,
         compile: program.compile.bind(program),
         verify: program.verify.bind(program),
         analyzeMethods: program.analyzeMethods.bind(program),
+        maxProofsVerified: program.maxProofsVerified.bind(program),
         Proof: SelfProofClass,
         methods,
       },
@@ -504,6 +513,7 @@ export class TransactionProver
     super();
     this.zkProgrammable = new TransactionProverZkProgrammable(
       this,
+      runtime,
       transactionHooks,
       stateServiceProvider,
       verificationKeyService

--- a/packages/protocol/test/BlockProver.test.ts
+++ b/packages/protocol/test/BlockProver.test.ts
@@ -4,13 +4,12 @@ import {
   PlainZkProgram,
   ZkProgrammable,
 } from "@proto-kit/common";
-import { Bool, Field, Proof, UInt64, ZkProgram } from "o1js";
+import { Field, Proof, UInt64, ZkProgram } from "o1js";
 import "reflect-metadata";
 
 import {
   MethodPublicOutput,
   NetworkState,
-  AuthorizedTransaction,
   StateTransitionProverPublicInput,
   StateTransitionProverPublicOutput,
 } from "../src";
@@ -38,7 +37,9 @@ class RuntimeZkProgrammable extends ZkProgrammable<
     return new MockAppChain();
   }
 
-  zkProgramFactory(): PlainZkProgram<undefined, MethodPublicOutput>[] {
+  public async zkProgramFactory(): Promise<
+    PlainZkProgram<undefined, MethodPublicOutput>[]
+  > {
     const program = ZkProgram({
       name: "BlockProverTestProgram",
       publicOutput: MethodPublicOutput,
@@ -48,9 +49,12 @@ class RuntimeZkProgrammable extends ZkProgrammable<
     return [
       {
         name: program.name,
+        publicInputType: program.publicInputType,
+        publicOutputType: program.publicOutputType,
         compile: program.compile.bind(program),
         verify: program.verify.bind(program),
         analyzeMethods: program.analyzeMethods.bind(program),
+        maxProofsVerified: program.maxProofsVerified.bind(program),
         methods: {},
         Proof: ZkProgram.Proof(program),
       },

--- a/packages/sequencer/package.json
+++ b/packages/sequencer/package.json
@@ -38,7 +38,8 @@
     "lodash-es": "^4.17.21",
     "mina-fungible-token": "^1.1.0",
     "reflect-metadata": "^0.1.13",
-    "ts-pattern": "^4.3.0"
+    "ts-pattern": "^4.3.0",
+    "typescript-memoize": "^1.1.1"
   },
   "gitHead": "8a7eca319272a15162dc4ad04bdc134b1017716d"
 }

--- a/packages/sequencer/src/helpers/CircuitAnalysisModule.ts
+++ b/packages/sequencer/src/helpers/CircuitAnalysisModule.ts
@@ -35,10 +35,10 @@ export class CircuitAnalysisModule {
 
     const zkProgrammablePromises = await mapSequential(
       zkProgrammables,
-      (withZkProgrammable) =>
-        mapSequential(
+      async (withZkProgrammable) =>
+        await mapSequential(
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          withZkProgrammable.zkProgrammable.zkProgramFactory() as PlainZkProgram<
+          (await withZkProgrammable.zkProgrammable.zkProgramFactory()) as PlainZkProgram<
             unknown,
             unknown
           >[],

--- a/packages/sequencer/src/helpers/utils.ts
+++ b/packages/sequencer/src/helpers/utils.ts
@@ -1,6 +1,6 @@
 import { Field, Proof, DynamicProof } from "o1js";
 import { Subclass } from "@proto-kit/protocol";
-import { MOCK_PROOF, TypedClass } from "@proto-kit/common";
+import { mapSequential, MOCK_PROOF, TypedClass } from "@proto-kit/common";
 import { Memoize } from "typescript-memoize";
 
 import { TaskSerializer } from "../worker/flow/Task";
@@ -74,12 +74,12 @@ abstract class ProofTaskSerializerBase<
     });
   }
 
-  public toJSON(
+  public async toJSON(
     proof:
       | Proof<PublicInputType, PublicOutputType>
       | DynamicProof<PublicInputType, PublicOutputType>
-  ): string {
-    return JSON.stringify(this.toJSONProof(proof));
+  ): Promise<string> {
+    return JSON.stringify(await this.toJSONProof(proof));
   }
 
   public async toJSONProof(
@@ -207,11 +207,13 @@ export class PairProofTaskSerializer<
     ];
   }
 
-  public toJSON(
+  public async toJSON(
     input: PairTuple<Proof<PublicInputType, PublicOutputType>>
-  ): string {
+  ): Promise<string> {
     return JSON.stringify(
-      input.map((element) => this.proofSerializer.toJSONProof(element))
+      await mapSequential(input, (element) =>
+        this.proofSerializer.toJSONProof(element)
+      )
     );
   }
 }

--- a/packages/sequencer/src/helpers/utils.ts
+++ b/packages/sequencer/src/helpers/utils.ts
@@ -1,6 +1,7 @@
 import { Field, Proof, DynamicProof } from "o1js";
 import { Subclass } from "@proto-kit/protocol";
 import { MOCK_PROOF, TypedClass } from "@proto-kit/common";
+import { Memoize } from "typescript-memoize";
 
 import { TaskSerializer } from "../worker/flow/Task";
 
@@ -30,28 +31,37 @@ export function distinctByString<Value extends { toString: () => string }>(
 
 type JsonProof = ReturnType<typeof Proof.prototype.toJSON>;
 
-abstract class ProofTaskSerializerBase<PublicInputType, PublicOutputType> {
+abstract class ProofTaskSerializerBase<
+  PublicInputType,
+  PublicOutputType,
+  Type extends
+    | (TypedClass<Proof<PublicInputType, PublicOutputType>> &
+        typeof Proof<PublicInputType, PublicOutputType>)
+    | (TypedClass<DynamicProof<PublicInputType, PublicOutputType>> &
+        typeof DynamicProof<PublicInputType, PublicOutputType>),
+> {
   protected constructor(
-    private readonly proofClassInternal: Subclass<
-      | typeof Proof<PublicInputType, PublicOutputType>
-      | typeof DynamicProof<PublicInputType, PublicOutputType>
-    >
+    private readonly proofClassInternalFun: () => Promise<Subclass<Type>>
   ) {}
 
-  protected getDummy<
-    T extends
-      | Proof<PublicInputType, PublicOutputType>
-      | DynamicProof<PublicInputType, PublicOutputType>,
-  >(c: TypedClass<T>, jsonProof: JsonProof): T {
+  @Memoize()
+  protected get proofClass() {
+    return this.proofClassInternalFun();
+  }
+
+  protected async getDummy(
+    c: Subclass<Type>,
+    jsonProof: JsonProof
+  ): Promise<InstanceType<Type>> {
+    const proofClass = await this.proofClass;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const publicInput: PublicInputType =
-      this.proofClassInternal.publicInputType.fromFields(
-        jsonProof.publicInput.map(Field),
-        []
-      );
+    const publicInput: PublicInputType = proofClass.publicInputType.fromFields(
+      jsonProof.publicInput.map(Field),
+      []
+    );
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const publicOutput: PublicOutputType =
-      this.proofClassInternal.publicOutputType.fromFields(
+      proofClass.publicOutputType.fromFields(
         jsonProof.publicOutput.map(Field),
         []
       );
@@ -72,20 +82,21 @@ abstract class ProofTaskSerializerBase<PublicInputType, PublicOutputType> {
     return JSON.stringify(this.toJSONProof(proof));
   }
 
-  public toJSONProof(
+  public async toJSONProof(
     proof:
       | Proof<PublicInputType, PublicOutputType>
       | DynamicProof<PublicInputType, PublicOutputType>
-  ): JsonProof {
+  ): Promise<JsonProof> {
     if (proof.proof === MOCK_PROOF) {
+      const proofClass = await this.proofClass;
       return {
-        publicInput: this.proofClassInternal.publicInputType
+        publicInput: proofClass.publicInputType
           // eslint-disable-next-line max-len
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-argument
           .toFields(proof.publicInput as any)
           .map(String),
 
-        publicOutput: this.proofClassInternal.publicOutputType
+        publicOutput: proofClass.publicOutputType
           // eslint-disable-next-line max-len
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions,@typescript-eslint/no-unsafe-argument
           .toFields(proof.publicOutput as any)
@@ -100,13 +111,15 @@ abstract class ProofTaskSerializerBase<PublicInputType, PublicOutputType> {
 }
 
 export class ProofTaskSerializer<PublicInputType, PublicOutputType>
-  extends ProofTaskSerializerBase<PublicInputType, PublicOutputType>
+  extends ProofTaskSerializerBase<
+    PublicInputType,
+    PublicOutputType,
+    typeof Proof<PublicInputType, PublicOutputType>
+  >
   implements TaskSerializer<Proof<PublicInputType, PublicOutputType>>
 {
   public constructor(
-    private readonly proofClass: Subclass<
-      typeof Proof<PublicInputType, PublicOutputType>
-    >
+    proofClass: () => Promise<typeof Proof<PublicInputType, PublicOutputType>>
   ) {
     super(proofClass);
   }
@@ -122,20 +135,24 @@ export class ProofTaskSerializer<PublicInputType, PublicOutputType>
     jsonProof: JsonProof
   ): Promise<Proof<PublicInputType, PublicOutputType>> {
     if (jsonProof.proof === MOCK_PROOF) {
-      return this.getDummy(this.proofClass, jsonProof);
+      return await this.getDummy(await this.proofClass, jsonProof);
     }
 
-    return await this.proofClass.fromJSON(jsonProof);
+    return await (await this.proofClass).fromJSON(jsonProof);
   }
 }
 
 export class DynamicProofTaskSerializer<PublicInputType, PublicOutputType>
-  extends ProofTaskSerializerBase<PublicInputType, PublicOutputType>
+  extends ProofTaskSerializerBase<
+    PublicInputType,
+    PublicOutputType,
+    typeof DynamicProof<PublicInputType, PublicOutputType>
+  >
   implements TaskSerializer<DynamicProof<PublicInputType, PublicOutputType>>
 {
   public constructor(
-    private readonly proofClass: Subclass<
-      typeof DynamicProof<PublicInputType, PublicOutputType>
+    proofClass: () => Promise<
+      Subclass<typeof DynamicProof<PublicInputType, PublicOutputType>>
     >
   ) {
     super(proofClass);
@@ -151,11 +168,11 @@ export class DynamicProofTaskSerializer<PublicInputType, PublicOutputType>
   public async fromJSONProof(
     jsonProof: JsonProof
   ): Promise<DynamicProof<PublicInputType, PublicOutputType>> {
-    if (jsonProof.proof === MOCK_PROOF) {
-      return this.getDummy(this.proofClass, jsonProof);
-    }
+    const proofClass = await this.proofClass;
 
-    const { proofClass } = this;
+    if (jsonProof.proof === MOCK_PROOF) {
+      return await this.getDummy(proofClass, jsonProof);
+    }
 
     return await proofClass.fromJSON(jsonProof);
   }
@@ -169,11 +186,13 @@ export class PairProofTaskSerializer<
 > implements TaskSerializer<
   PairTuple<Proof<PublicInputType, PublicOutputType>>
 > {
-  private readonly proofSerializer = new ProofTaskSerializer(this.proofClass);
+  private readonly proofSerializer = new ProofTaskSerializer(
+    this.proofClassFun
+  );
 
   public constructor(
-    private readonly proofClass: Subclass<
-      typeof Proof<PublicInputType, PublicOutputType>
+    private readonly proofClassFun: () => Promise<
+      Subclass<typeof Proof<PublicInputType, PublicOutputType>>
     >
   ) {}
 

--- a/packages/sequencer/src/protocol/production/BatchProducerModule.ts
+++ b/packages/sequencer/src/protocol/production/BatchProducerModule.ts
@@ -106,7 +106,7 @@ export class BatchProducerModule extends SequencerModule {
 
     const blockHashes = blocks.map((bundle) => bundle.block.hash.toString());
 
-    const jsonProof = this.blockProofSerializer
+    const jsonProof = await this.blockProofSerializer
       .getBlockProofSerializer()
       .toJSONProof(batch.proof);
 

--- a/packages/sequencer/src/protocol/production/flow/BatchFlow.ts
+++ b/packages/sequencer/src/protocol/production/flow/BatchFlow.ts
@@ -65,16 +65,20 @@ export class BatchFlow {
     }
   }
 
-  private dummySTProof() {
-    return this.protocol.stateTransitionProver.zkProgrammable.zkProgram[0].Proof.dummy(
+  private async dummySTProof() {
+    const program =
+      await this.protocol.stateTransitionProver.zkProgrammable.zkProgram();
+    return await program[0].Proof.dummy(
       StateTransitionProverPublicInput.empty(),
       StateTransitionProverPublicOutput.empty(),
       2
     );
   }
 
-  private dummyTransactionProof() {
-    return this.protocol.transactionProver.zkProgrammable.zkProgram[0].Proof.dummy(
+  private async dummyTransactionProof() {
+    const program =
+      await this.protocol.transactionProver.zkProgrammable.zkProgram();
+    return await program[0].Proof.dummy(
       TransactionProverPublicInput.empty(),
       TransactionProverPublicInput.empty(),
       2

--- a/packages/sequencer/src/protocol/production/flow/StateTransitionFlow.ts
+++ b/packages/sequencer/src/protocol/production/flow/StateTransitionFlow.ts
@@ -37,11 +37,9 @@ export class StateTransitionFlow {
       witnessedRootsHash: Field(0),
     };
 
-    return await this.protocol.stateTransitionProver.zkProgrammable.zkProgram[0].Proof.dummy(
-      emptyInputOutput,
-      emptyInputOutput,
-      2
-    );
+    const program =
+      await this.protocol.stateTransitionProver.zkProgrammable.zkProgram();
+    return await program[0].Proof.dummy(emptyInputOutput, emptyInputOutput, 2);
   }
 
   private createFlow(name: string, inputLength: number) {

--- a/packages/sequencer/src/protocol/production/tasks/BlockReductionTask.ts
+++ b/packages/sequencer/src/protocol/production/tasks/BlockReductionTask.ts
@@ -58,14 +58,14 @@ export class BlockReductionTask
   }
 
   public inputSerializer(): TaskSerializer<PairTuple<BlockProof>> {
-    return new PairProofTaskSerializer(
-      this.blockProver.zkProgrammable.zkProgram[0].Proof
+    return new PairProofTaskSerializer(() =>
+      this.blockProver.zkProgrammable.proofType()
     );
   }
 
   public resultSerializer(): TaskSerializer<BlockProof> {
-    return new ProofTaskSerializer(
-      this.blockProver.zkProgrammable.zkProgram[0].Proof
+    return new ProofTaskSerializer(() =>
+      this.blockProver.zkProgrammable.proofType()
     );
   }
 

--- a/packages/sequencer/src/protocol/production/tasks/NewBlockTask.ts
+++ b/packages/sequencer/src/protocol/production/tasks/NewBlockTask.ts
@@ -15,8 +15,6 @@ import {
   BlockArgumentsBatch,
   BlockProverStateInput,
   ProtocolConstants,
-  DynamicSTProof,
-  DynamicTransactionProof,
 } from "@proto-kit/protocol";
 import { Bool } from "o1js";
 import {
@@ -97,12 +95,12 @@ export class NewBlockTask
   }
 
   public inputSerializer(): TaskSerializer<NewBlockProvingParameters> {
-    const stProofSerializer = new ProofTaskSerializer(
-      this.stateTransitionProver.zkProgrammable.zkProgram[0].Proof
+    const stProofSerializer = new ProofTaskSerializer(() =>
+      this.stateTransitionProver.zkProgrammable.proofType()
     );
 
-    const transactionProofSerializer = new ProofTaskSerializer(
-      this.transactionProver.zkProgrammable.zkProgram[0].Proof
+    const transactionProofSerializer = new ProofTaskSerializer(() =>
+      this.transactionProver.zkProgrammable.proofType()
     );
 
     return new NewBlockProvingParametersSerializer(
@@ -112,8 +110,8 @@ export class NewBlockTask
   }
 
   public resultSerializer(): TaskSerializer<BlockProof> {
-    return new ProofTaskSerializer(
-      this.blockProver.zkProgrammable.zkProgram[0].Proof
+    return new ProofTaskSerializer(() =>
+      this.blockProver.zkProgrammable.proofType()
     );
   }
 
@@ -157,11 +155,16 @@ export class NewBlockTask
             blockWitness,
             blockArgumentBatch,
             Bool(false)
-            // deferSTProof.or(deferTransactionProof)
           );
         } else {
+          const DynamicSTProof =
+            await this.stateTransitionProver.zkProgrammable.dynamicProofType();
           const stProof = DynamicSTProof.fromProof(input1);
+
+          const DynamicTransactionProof =
+            await this.transactionProver.zkProgrammable.dynamicProofType();
           const txProof = DynamicTransactionProof.fromProof(input2);
+
           await this.blockProver.proveBlockBatchWithProofs(
             publicInput,
             stateWitness,

--- a/packages/sequencer/src/protocol/production/tasks/RuntimeProvingTask.ts
+++ b/packages/sequencer/src/protocol/production/tasks/RuntimeProvingTask.ts
@@ -67,7 +67,9 @@ export class RuntimeProvingTask
   }
 
   public resultSerializer(): TaskSerializer<RuntimeProof> {
-    return new ProofTaskSerializer(this.runtimeZkProgrammable[0].Proof);
+    return new ProofTaskSerializer(() =>
+      this.runtime.zkProgrammable.proofType()
+    );
   }
 
   public async compute(input: RuntimeProofParameters): Promise<RuntimeProof> {

--- a/packages/sequencer/src/protocol/production/tasks/StateTransitionReductionTask.ts
+++ b/packages/sequencer/src/protocol/production/tasks/StateTransitionReductionTask.ts
@@ -59,14 +59,14 @@ export class StateTransitionReductionTask
   }
 
   public inputSerializer(): TaskSerializer<PairTuple<StateTransitionProof>> {
-    return new PairProofTaskSerializer(
-      this.stateTransitionProver.zkProgrammable.zkProgram[0].Proof
+    return new PairProofTaskSerializer(() =>
+      this.stateTransitionProver.zkProgrammable.proofType()
     );
   }
 
   public resultSerializer(): TaskSerializer<StateTransitionProof> {
-    return new ProofTaskSerializer(
-      this.stateTransitionProver.zkProgrammable.zkProgram[0].Proof
+    return new ProofTaskSerializer(() =>
+      this.stateTransitionProver.zkProgrammable.proofType()
     );
   }
 

--- a/packages/sequencer/src/protocol/production/tasks/StateTransitionTask.ts
+++ b/packages/sequencer/src/protocol/production/tasks/StateTransitionTask.ts
@@ -63,8 +63,8 @@ export class StateTransitionTask
   }
 
   public resultSerializer(): TaskSerializer<StateTransitionProof> {
-    return new ProofTaskSerializer(
-      this.stateTransitionProver.zkProgrammable.zkProgram[0].Proof
+    return new ProofTaskSerializer(() =>
+      this.stateTransitionProver.zkProgrammable.proofType()
     );
   }
 

--- a/packages/sequencer/src/protocol/production/tasks/TransactionProvingTask.ts
+++ b/packages/sequencer/src/protocol/production/tasks/TransactionProvingTask.ts
@@ -62,9 +62,6 @@ export class TransactionProvingTask
 {
   private readonly transactionProver: TransactionProvable;
 
-  private readonly runtimeProofType =
-    this.runtime.zkProgrammable.zkProgram[0].Proof;
-
   public name = "transaction";
 
   public constructor(
@@ -88,9 +85,13 @@ export class TransactionProvingTask
     };
   }
 
+  private async runtimeProofType() {
+    return await this.runtime.zkProgrammable.proofType();
+  }
+
   public inputSerializer(): TaskSerializer<TransactionProvingTaskParameters> {
     const runtimeProofSerializer = new ProofTaskSerializer(
-      this.runtimeProofType
+      this.runtimeProofType.bind(this)
     );
     return new TransactionProvingTaskParameterSerializer(
       runtimeProofSerializer
@@ -98,8 +99,8 @@ export class TransactionProvingTask
   }
 
   public resultSerializer(): TaskSerializer<TransactionProof> {
-    return new ProofTaskSerializer(
-      this.transactionProver.zkProgrammable.zkProgram[0].Proof
+    return new ProofTaskSerializer(() =>
+      this.transactionProver.zkProgrammable.proofType()
     );
   }
 

--- a/packages/sequencer/src/protocol/production/tasks/TransactionReductionTask.ts
+++ b/packages/sequencer/src/protocol/production/tasks/TransactionReductionTask.ts
@@ -58,14 +58,14 @@ export class TransactionReductionTask
   }
 
   public inputSerializer(): TaskSerializer<PairTuple<TransactionProof>> {
-    return new PairProofTaskSerializer(
-      this.transactionProver.zkProgrammable.zkProgram[0].Proof
+    return new PairProofTaskSerializer(() =>
+      this.transactionProver.zkProgrammable.proofType()
     );
   }
 
   public resultSerializer(): TaskSerializer<TransactionProof> {
-    return new ProofTaskSerializer(
-      this.transactionProver.zkProgrammable.zkProgram[0].Proof
+    return new ProofTaskSerializer(() =>
+      this.transactionProver.zkProgrammable.proofType()
     );
   }
 

--- a/packages/sequencer/src/protocol/production/tasks/serializers/BlockProofSerializer.ts
+++ b/packages/sequencer/src/protocol/production/tasks/serializers/BlockProofSerializer.ts
@@ -24,8 +24,9 @@ export class BlockProofSerializer {
   public getBlockProofSerializer() {
     if (this.serializer === undefined) {
       const blockProver = this.protocol.resolve("BlockProver");
-      const proofType = blockProver.zkProgrammable.zkProgram[0].Proof;
-      this.serializer = new ProofTaskSerializer(proofType);
+      this.serializer = new ProofTaskSerializer(() =>
+        blockProver.zkProgrammable.proofType()
+      );
     }
     return this.serializer;
   }

--- a/packages/sequencer/src/protocol/production/tasks/serializers/NewBlockProvingParametersSerializer.ts
+++ b/packages/sequencer/src/protocol/production/tasks/serializers/NewBlockProvingParametersSerializer.ts
@@ -60,10 +60,10 @@ export class NewBlockProvingParametersSerializer implements TaskSerializer<NewBl
     >
   ) {}
 
-  public toJSON(input: NewBlockPayload) {
+  public async toJSON(input: NewBlockPayload) {
     return JSON.stringify({
-      input1: this.stProofSerializer.toJSON(input.input1),
-      input2: this.transactionProofSerializer.toJSON(input.input2),
+      input1: await this.stProofSerializer.toJSON(input.input1),
+      input2: await this.transactionProofSerializer.toJSON(input.input2),
 
       params: {
         publicInput: BlockProverPublicInput.toJSON(input.params.publicInput),

--- a/packages/sequencer/src/protocol/production/tasks/serializers/TransactionProvingTaskParameterSerializer.ts
+++ b/packages/sequencer/src/protocol/production/tasks/serializers/TransactionProvingTaskParameterSerializer.ts
@@ -81,17 +81,19 @@ export class TransactionProvingTaskParameterSerializer implements TaskSerializer
     };
   }
 
-  public toJSON(inputs: TransactionProvingTaskParameters): string {
+  public async toJSON(
+    inputs: TransactionProvingTaskParameters
+  ): Promise<string> {
     if (inputs === "dummy") {
       return "dummy";
     }
 
-    const taskParamsJson: TransactionProvingTaskParametersJSON = inputs.map(
-      (input) => {
+    const taskParamsJson: TransactionProvingTaskParametersJSON =
+      await mapSequential(inputs, async (input) => {
         const { parameters, proof } = input;
         const { executionData } = parameters;
 
-        const proofJSON = this.runtimeProofSerializer.toJSONProof(proof);
+        const proofJSON = await this.runtimeProofSerializer.toJSONProof(proof);
 
         const parametersJSON: TransactionProverTaskParametersJSON = {
           publicInput: TransactionProverPublicInput.toJSON(
@@ -112,8 +114,7 @@ export class TransactionProvingTaskParameterSerializer implements TaskSerializer
         };
 
         return { parameters: parametersJSON, proof: proofJSON };
-      }
-    );
+      });
 
     return JSON.stringify(taskParamsJson);
   }

--- a/packages/sequencer/src/protocol/runtime/RuntimeVerificationKeyService.ts
+++ b/packages/sequencer/src/protocol/runtime/RuntimeVerificationKeyService.ts
@@ -64,7 +64,7 @@ export class VerificationKeyService extends ConfigurableModule<{}> {
 
   public async initializeVKTree(artifacts: Record<string, CompileArtifact>) {
     const mappings = await mapSequential(
-      this.runtime.zkProgrammable.zkProgram,
+      await this.runtime.zkProgrammable.zkProgram(),
       async (program) => {
         const artifact = artifacts[program.name];
 

--- a/packages/sequencer/src/sequencer/SequencerStartupModule.ts
+++ b/packages/sequencer/src/sequencer/SequencerStartupModule.ts
@@ -104,13 +104,17 @@ export class SequencerStartupModule
     return root;
   }
 
-  private async compileBridge(flow: Flow<{}>, isSignedSettlement?: boolean) {
+  private async compileBridge(
+    flow: Flow<{}>,
+    runtimeVKRoot: bigint,
+    isSignedSettlement?: boolean
+  ) {
     const result = await flow.withFlow<ArtifactRecord>(async (res, rej) => {
       await flow.pushTask(
         this.settlementCompileTask,
         {
           existingArtifacts: this.compileRegistry.getAllArtifacts(),
-          runtimeVKRoot: undefined,
+          runtimeVKRoot: runtimeVKRoot.toString(),
           isSignedSettlement,
         },
         async (bridgeResult) => {
@@ -184,6 +188,7 @@ export class SequencerStartupModule
     if (this.settlementModule !== undefined) {
       const bridgeArtifacts = await this.compileBridge(
         flow,
+        root,
         isSignedSettlement
       );
 

--- a/packages/sequencer/src/settlement/tasks/SettlementProvingTask.ts
+++ b/packages/sequencer/src/settlement/tasks/SettlementProvingTask.ts
@@ -182,11 +182,11 @@ export class SettlementProvingTask
     return proofType.prototype instanceof Proof
       ? new ProofTaskSerializer(
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          proofType as Subclass<typeof Proof<any, any>>
+          async () => proofType as Subclass<typeof Proof<any, any>>
         )
       : new DynamicProofTaskSerializer(
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          proofType as Subclass<typeof DynamicProof<any, any>>
+          async () => proofType as Subclass<typeof DynamicProof<any, any>>
         );
   }
 

--- a/packages/sequencer/src/settlement/tasks/SettlementProvingTask.ts
+++ b/packages/sequencer/src/settlement/tasks/SettlementProvingTask.ts
@@ -341,85 +341,85 @@ export class SettlementProvingTask
         };
       },
 
-      toJSON: (input: TransactionTaskArgs): string => {
+      toJSON: async (input: TransactionTaskArgs): Promise<string> => {
         const transaction = input.transaction.toJSON();
 
-        const lazyProofs =
-          input.transaction.transaction.accountUpdates.map<LazyProofJson | null>(
-            (au) => {
-              if (au.lazyAuthorization?.kind === "lazy-proof") {
-                const lazyProof = au.lazyAuthorization;
+        const lazyProofs = await mapSequential(
+          input.transaction.transaction.accountUpdates,
+          async (au) => {
+            if (au.lazyAuthorization?.kind === "lazy-proof") {
+              const lazyProof = au.lazyAuthorization;
 
-                // eslint-disable-next-line no-underscore-dangle
-                const method = lazyProof.ZkappClass._methods?.find(
-                  (methodInterface) =>
-                    methodInterface.methodName === lazyProof.methodName
-                );
-                if (method === undefined) {
-                  throw new Error("Method interface not found");
-                }
+              // eslint-disable-next-line no-underscore-dangle
+              const method = lazyProof.ZkappClass._methods?.find(
+                (methodInterface) =>
+                  methodInterface.methodName === lazyProof.methodName
+              );
+              if (method === undefined) {
+                throw new Error("Method interface not found");
+              }
 
-                // args are [public key, tokenId, ...args]
-                const args = method.args.slice(2);
+              // args are [public key, tokenId, ...args]
+              const args = method.args.slice(2);
 
-                const encodedArgs = lazyProof.args
-                  .map((arg, index) => {
-                    const argType = args[index];
-                    const argTypeProvable = ProvableType.get(argType);
-                    const argProofs = this.extractProofTypes(argType);
+              const encodedArgs = (
+                await mapSequential(lazyProof.args, async (arg, index) => {
+                  const argType = args[index];
+                  const argTypeProvable = ProvableType.get(argType);
+                  const argProofs = this.extractProofTypes(argType);
 
-                    if (argProofs.length === 0) {
-                      // Special case for AUForest
-                      if (arg instanceof AccountUpdateForest) {
-                        const accountUpdates = AccountUpdateForest.toFlatArray(
-                          arg
-                        ).map((update) => AccountUpdate.toJSON(update));
-
-                        return {
-                          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-                          fields: [] as string[],
-                          aux: [
-                            JSON.stringify({
-                              accountUpdates,
-                              typeName: "AccountUpdateForest",
-                            }),
-                          ],
-                        };
-                      }
-
-                      const fields = argTypeProvable
-                        .toFields(arg)
-                        .map((f) => f.toString());
-                      const aux = argTypeProvable
-                        .toAuxiliary(arg)
-                        .map((x) => JSON.stringify(x));
+                  if (argProofs.length === 0) {
+                    // Special case for AUForest
+                    if (arg instanceof AccountUpdateForest) {
+                      const accountUpdates = AccountUpdateForest.toFlatArray(
+                        arg
+                      ).map((update) => AccountUpdate.toJSON(update));
 
                       return {
-                        fields,
-                        aux,
+                        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                        fields: [] as string[],
+                        aux: [
+                          JSON.stringify({
+                            accountUpdates,
+                            typeName: "AccountUpdateForest",
+                          }),
+                        ],
                       };
-                    } else {
-                      const serializer = this.getProofSerializer(argProofs[0]);
-                      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                      return serializer.toJSON(arg);
                     }
-                  })
-                  .filter(filterNonUndefined);
 
-                return {
-                  methodName: lazyProof.methodName,
-                  zkappClassName: lazyProof.ZkappClass.name,
-                  args: encodedArgs,
-                  blindingValue: lazyProof.blindingValue.toString(),
-                  memoized: lazyProof.memoized.map((value) => ({
-                    fields: value.fields.map((f) => f.toString()),
-                    aux: value.aux,
-                  })),
-                };
-              }
-              return null;
+                    const fields = argTypeProvable
+                      .toFields(arg)
+                      .map((f) => f.toString());
+                    const aux = argTypeProvable
+                      .toAuxiliary(arg)
+                      .map((x) => JSON.stringify(x));
+
+                    return {
+                      fields,
+                      aux,
+                    };
+                  } else {
+                    const serializer = this.getProofSerializer(argProofs[0]);
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                    return await serializer.toJSON(arg);
+                  }
+                })
+              ).filter(filterNonUndefined);
+
+              return {
+                methodName: lazyProof.methodName,
+                zkappClassName: lazyProof.ZkappClass.name,
+                args: encodedArgs,
+                blindingValue: lazyProof.blindingValue.toString(),
+                memoized: lazyProof.memoized.map((value) => ({
+                  fields: value.fields.map((f) => f.toString()),
+                  aux: value.aux,
+                })),
+              };
             }
-          );
+            return null;
+          }
+        );
 
         const jsonObject: JsonInputObject = {
           transaction,

--- a/packages/sequencer/test-proven/Proven.test.ts
+++ b/packages/sequencer/test-proven/Proven.test.ts
@@ -18,7 +18,7 @@ import {
 } from "@proto-kit/protocol";
 import { VanillaProtocolModules } from "@proto-kit/library";
 import { container } from "tsyringe";
-import { PrivateKey, UInt64 } from "o1js";
+import { PrivateKey, Provable, UInt64, VerificationKey } from "o1js";
 
 import { testingSequencerModules } from "../test/TestingSequencer";
 import {
@@ -127,7 +127,7 @@ describe("Proven", () => {
       try {
         // Start AppChain
         const childContainer = container.createChildContainer();
-        await app.start(true, childContainer);
+        await app.start(false, childContainer);
 
         test = app.sequencer.dependencyContainer.resolve(BlockTestService);
 
@@ -190,7 +190,7 @@ describe("Proven", () => {
     }
   }, 500000);
 
-  it(
+  it.skip(
     "should produce simple block",
     async () => {
       expect.assertions(6);
@@ -221,7 +221,8 @@ describe("Proven", () => {
     },
     timeout
   );
-  it(
+
+  it.skip(
     "should produce large block",
     async () => {
       log.setLevel("INFO");
@@ -248,6 +249,45 @@ describe("Proven", () => {
       await test.produceBlock();
       await test.produceBlock();
       await test.produceBlock();
+      const batch = await test.produceBatch();
+
+      expectDefined(batch);
+
+      console.log(batch.proof);
+
+      expect(batch.blockHashes).toHaveLength(6);
+      expect(batch.proof.proof.length).toBeGreaterThan(50);
+    },
+    timeout * 10
+  );
+
+  it(
+    "should produce empty + 1 tx",
+    async () => {
+      log.setLevel("INFO");
+
+      const privateKey = PrivateKey.random();
+
+      // await test.produceBlock();
+      // await test.produceBlock();
+      // await test.produceBlock();
+
+      await test.addTransaction({
+        method: ["Balances", "addBalance"],
+        privateKey,
+        args: [PrivateKey.random().toPublicKey(), UInt64.from(100)],
+      });
+
+      // Produce 6 blocks, 5 txs each into 1 batch
+      const block = await test.produceBlock();
+      await test.produceBlock();
+      await test.produceBlock();
+      await test.produceBlock();
+
+      expectDefined(block);
+      expect(block.transactions).toHaveLength(1);
+      expect(block.transactions[0].status.toBoolean()).toBe(true);
+
       const batch = await test.produceBatch();
 
       expectDefined(batch);

--- a/packages/sequencer/test-proven/Proven.test.ts
+++ b/packages/sequencer/test-proven/Proven.test.ts
@@ -127,7 +127,7 @@ describe("Proven", () => {
       try {
         // Start AppChain
         const childContainer = container.createChildContainer();
-        await app.start(false, childContainer);
+        await app.start(true, childContainer);
 
         test = app.sequencer.dependencyContainer.resolve(BlockTestService);
 
@@ -190,7 +190,7 @@ describe("Proven", () => {
     }
   }, 500000);
 
-  it.skip(
+  it(
     "should produce simple block",
     async () => {
       expect.assertions(6);
@@ -222,7 +222,7 @@ describe("Proven", () => {
     timeout
   );
 
-  it.skip(
+  it(
     "should produce large block",
     async () => {
       log.setLevel("INFO");
@@ -294,7 +294,7 @@ describe("Proven", () => {
 
       console.log(batch.proof);
 
-      expect(batch.blockHashes).toHaveLength(6);
+      expect(batch.blockHashes).toHaveLength(4);
       expect(batch.proof.proof.length).toBeGreaterThan(50);
     },
     timeout * 10

--- a/packages/sequencer/test/integration/BlockProduction-test.ts
+++ b/packages/sequencer/test/integration/BlockProduction-test.ts
@@ -189,7 +189,7 @@ export function testBlockProduction<
       app.sequencer.dependencyContainer.resolve<AsyncLinkedLeafStore>(
         "UnprovenLinkedLeafStore"
       );
-  });
+  }, 30000);
 
   afterEach(async () => {
     await appChain.close();


### PR DESCRIPTION
Based on #471 

This PR adds functionality to automatically determine the correct `maxProofsVerified` and `featureFlags` values for dynamic proofs from a given ZkProgrammable. Used for consumption in other circuits by calling `dependency.dynamicProofType()`.
This PR also integrates this change into the protocol circuits (BlockProver mainly)