### PR TITLE
More adaptive block result recomputation

### DIFF
--- a/packages/sdk/src/query/BlockStorageNetworkStateModule.ts
+++ b/packages/sdk/src/query/BlockStorageNetworkStateModule.ts
@@ -38,7 +38,7 @@ export class BlockStorageNetworkStateModule
   }
 
   public async getUnprovenNetworkState(): Promise<NetworkState | undefined> {
-    const latestBlock = await this.unprovenStorage.getLatestBlock();
+    const latestBlock = await this.unprovenQueue.getLatestBlockAndResult();
     return latestBlock?.block.networkState.during;
   }
 
@@ -47,6 +47,8 @@ export class BlockStorageNetworkStateModule
    * with afterBundle() hooks executed
    */
   public async getStagedNetworkState(): Promise<NetworkState | undefined> {
+    // TODO Result could be null here, add method that specifically looks for the
+    //  last block with a result
     const result = await this.unprovenStorage.getLatestBlock();
     return result?.result.afterNetworkState;
   }

--- a/packages/sequencer/src/logging/ConsoleTracer.ts
+++ b/packages/sequencer/src/logging/ConsoleTracer.ts
@@ -14,7 +14,7 @@ type StoreType = Record<string, { duration: number }[]>;
 @closeable()
 export class ConsoleTracer implements Tracer {
   // Hard-code this for the moment. Needs to be configured.
-  timeInterval: number = 60000;
+  timeInterval: number = 180000;
 
   store: StoreType = {};
 

--- a/packages/sequencer/src/protocol/production/sequencing/BlockProducerModule.ts
+++ b/packages/sequencer/src/protocol/production/sequencing/BlockProducerModule.ts
@@ -140,6 +140,9 @@ export class BlockProducerModule extends SequencerModule<BlockConfig> {
 
   @ensureNotBusy()
   public async tryProduceBlock(): Promise<Block | undefined> {
+    // Check if previous result has been computed, and if not, compute it
+    await this.blockResultCompleteCheck();
+
     const block = await this.produceBlock();
 
     if (block === undefined) {
@@ -239,19 +242,23 @@ export class BlockProducerModule extends SequencerModule<BlockConfig> {
     return blockResult?.block;
   }
 
-  public async blockResultCompleteCheck() {
+  public async blockResultCompleteCheck(): Promise<
+    "genesis" | "existent" | "generated"
+  > {
     // Check if metadata height is behind block production.
     // This can happen when the sequencer crashes after a block has been produced
     // but before the metadata generation has finished
     const latestBlock = await this.blockQueue.getLatestBlockAndResult();
-    // eslint-disable-next-line sonarjs/no-collapsible-if
     if (latestBlock !== undefined) {
       if (latestBlock.result === undefined) {
         await this.generateMetadata(latestBlock.block);
+        return "generated";
       }
       // Here, the metadata has been computed already
+      return "existent";
     }
     // If we reach here, its a genesis startup, no blocks exist yet
+    return "genesis";
   }
 
   public async start() {

--- a/packages/sequencer/src/settlement/messages/IncomingMessagesService.ts
+++ b/packages/sequencer/src/settlement/messages/IncomingMessagesService.ts
@@ -3,7 +3,7 @@ import { ACTIONS_EMPTY_HASH } from "@proto-kit/protocol";
 
 import { SettlementStorage } from "../../storage/repositories/SettlementStorage";
 import { MessageStorage } from "../../storage/repositories/MessageStorage";
-import { BlockStorage } from "../../storage/repositories/BlockStorage";
+import { BlockQueue } from "../../storage/repositories/BlockStorage";
 import { PendingTransaction } from "../../mempool/PendingTransaction";
 import type { BridgingModule } from "../BridgingModule";
 
@@ -18,8 +18,8 @@ export class IncomingMessagesService {
     private readonly messageStorage: MessageStorage,
     @inject("IncomingMessageAdapter")
     private readonly messagesAdapter: IncomingMessageAdapter,
-    @inject("BlockStorage")
-    private readonly blockStorage: BlockStorage,
+    @inject("BlockQueue")
+    private readonly blockStorage: BlockQueue,
     @inject("BridgingModule")
     private readonly bridgingModule: BridgingModule
   ) {}
@@ -102,7 +102,7 @@ export class IncomingMessagesService {
 
   public async getPendingMessages() {
     const latestSettlement = await this.settlementStorage.getLatestSettlement();
-    const latestBlock = await this.blockStorage.getLatestBlock();
+    const latestBlock = await this.blockStorage.getLatestBlockAndResult();
 
     const messagesHashCursor =
       latestBlock?.block?.toMessagesHash?.toString() ??

--- a/packages/sequencer/test/protocol/production/sequencing/atomic-block-production.test.ts
+++ b/packages/sequencer/test/protocol/production/sequencing/atomic-block-production.test.ts
@@ -89,7 +89,7 @@ describe("atomic block production", () => {
    * the second block production can succeed
    */
   it("should recover from non-generated metadata", async () => {
-    expect.assertions(6);
+    expect.assertions(5);
 
     const module =
       appchain.sequencer.dependencyContainer.resolve(BlockResultService);
@@ -100,9 +100,6 @@ describe("atomic block production", () => {
         throw new Error("Test error");
       });
 
-    await expect(() => trigger.produceBlock()).rejects.toThrow();
-
-    // This checks that it correctly throws when producing a block with no previous result existing
     await expect(() => trigger.produceBlock()).rejects.toThrow();
 
     await appchain.sequencer


### PR DESCRIPTION
Based on #473 

This PR adds a bit of stability towards missing block results. Specifically, it checks for missing results for every block to account for 1. failed result computation itself and more likely 2. network errors during database writes of the result